### PR TITLE
feat: Update skill display names in frontmatter

### DIFF
--- a/config/skills/langchain-fundamentals/SKILL.md
+++ b/config/skills/langchain-fundamentals/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: langchain-fundamentals
+name: LangChain Fundamentals
 description: Create LangChain agents with create_agent, define tools, and use middleware for human-in-the-loop and error handling
 ---
 

--- a/config/skills/langsmith-dataset/SKILL.md
+++ b/config/skills/langsmith-dataset/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: langsmith-dataset
+name: LangSmith Datasets
 description: "INVOKE THIS SKILL when creating evaluation datasets from traces OR uploading datasets to LangSmith. Covers dataset types (final_response, single_step, trajectory, RAG) and LangSmith upload. Contains helper scripts to use or refer to."
 ---
 

--- a/config/skills/langsmith-evaluator/SKILL.md
+++ b/config/skills/langsmith-evaluator/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: langsmith-evaluator
+name: LangSmith Evaluators
 description: "INVOKE THIS SKILL when creating evaluators for LangSmith OR running evaluations on datasets. Covers LLM-as-Judge evaluators, custom code evaluators, and uploading to LangSmith. Contains helper scripts to use or refer to."
 ---
 

--- a/config/skills/langsmith-trace/SKILL.md
+++ b/config/skills/langsmith-trace/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: langsmith-trace
+name: LangSmith Traces
 description: "INVOKE THIS SKILL when working with LangSmith tracing OR querying traces. Covers adding tracing to applications and querying/exporting trace data. Contains helper scripts to use or refer to"
 ---
 


### PR DESCRIPTION
## Summary                                                           
   - Updated display names in SKILL.md frontmatter for langchain-fundamentals   
    and langsmith skills                                                        
   - Changes from kebab-case to human-readable format (e.g.,                    
   `langchain-fundamentals` → `LangChain Fundamentals`)