### PR TITLE
fix: add is_enabled and include_extended_stats to evaluator payload

### DIFF
--- a/config/skills/langsmith-evaluator/scripts/upload_evaluators.py
+++ b/config/skills/langsmith-evaluator/scripts/upload_evaluators.py
@@ -264,6 +264,8 @@ def create_evaluator(payload: EvaluatorPayload) -> bool:
     data = {
         "display_name": payload.display_name,
         "sampling_rate": payload.sampling_rate,
+        "is_enabled": True,
+        "include_extended_stats": False,
         "code_evaluators": [{"code": e.code, "language": e.language} for e in payload.evaluators],
     }
 

--- a/config/skills/langsmith-evaluator/scripts/upload_evaluators.ts
+++ b/config/skills/langsmith-evaluator/scripts/upload_evaluators.ts
@@ -348,6 +348,8 @@ export async function createEvaluator(
   const data: Record<string, unknown> = {
     display_name: payload.display_name,
     sampling_rate: payload.sampling_rate,
+    is_enabled: true,
+    include_extended_stats: false,
     code_evaluators: payload.evaluators.map((e) => ({
       code: e.code,
       language: e.language,


### PR DESCRIPTION
## Summary
- Adds `is_enabled: true` and `include_extended_stats: false` to evaluator upload payload
- Aligns our API payload with what the LangSmith UI sends, ensuring full parity
- Applied to both Python and TypeScript upload scripts

## Test plan
- [x] Compared payload field-by-field against LangSmith UI payload
- [x] Verified both script files updated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)