### PR TITLE
docs: add local install one-liners

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ These skills can be installed for the following AI coding agents:
 
 ## Installation
 
+### Quick Install (Local)
+
+Install into the current directory with a single command (run from your project root):
+
+**Claude Code:**
+```bash
+curl -fsSL https://github.com/langchain-ai/langchain-skills/archive/main.tar.gz | tar -xz -C /tmp && /tmp/langchain-skills-main/install.sh -y && rm -rf /tmp/langchain-skills-main
+```
+
+**DeepAgents CLI:**
+```bash
+curl -fsSL https://github.com/langchain-ai/langchain-skills/archive/main.tar.gz | tar -xz -C /tmp && /tmp/langchain-skills-main/install.sh --deepagents -y && rm -rf /tmp/langchain-skills-main
+```
+
 ### Quick Install (Global)
 
 Install globally with a single command:


### PR DESCRIPTION
## Summary

- Adds Quick Install (Local) section to README with one-liners for both Claude Code and DeepAgents CLI
- Places local install before global install since it's the more common use case

## Test Plan

- [x] Tested Claude Code local one-liner in fresh directory — all 14 skills installed to `.claude/skills/`
- [x] Tested duplicate handling — existing skills skipped with warning
- [x] Tested partial reinstall — deleted 3 skills, re-ran one-liner, only missing skills restored
- [x] Repeated all tests for DeepAgents local one-liner — identical behavior to `.deepagents/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)