### PR TITLE
fix: update skill imports for langchain/langgraph v1.x

### DIFF
--- a/config/skills/deep-agents-orchestration/SKILL.md
+++ b/config/skills/deep-agents-orchestration/SKILL.md
@@ -293,7 +293,7 @@ Complete workflow: trigger an interrupt, check state, approve action, and resume
 ```python
 from deepagents import create_deep_agent
 from langgraph.checkpoint.memory import MemorySaver
-from langchain.schema import Command
+from langgraph.types import Command
 
 agent = create_deep_agent(
     interrupt_on={"write_file": True},

--- a/config/skills/langchain-dependencies/SKILL.md
+++ b/config/skills/langchain-dependencies/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: LangChain Dependencies
-description: "INVOKE THIS SKILL when setting up a NEW project or when asked about package versions, installation, or dependency management for LangChain, LangGraph, LangSmith, or Deep Agents. Covers required packages, minimum versions, environment requirements, versioning best practices, and common community tool packages for both Python and TypeScript. Not opinionated about which package manager to use."
+description: "INVOKE THIS SKILL when setting up a new project or when asked about package versions, installation, or dependency management for LangChain, LangGraph, LangSmith, or Deep Agents. Covers required packages, minimum versions, environment requirements, versioning best practices, and common community tool packages for both Python and TypeScript."
 ---
 
 <overview>
@@ -87,7 +87,7 @@ These packages have tighter compatibility requirements — use the latest availa
 
 | Package | Adds | Notes |
 |---------|------|-------|
-| `langchain-tavily` | Tavily web search tool | Dedicated integration package; prefer latest |
+| `langchain-tavily` | Tavily web search (`TavilySearch`) | Dedicated integration package; prefer latest |
 | `langchain-text-splitters` | Text chunking utilities | Semver, keep current |
 | `langchain-community` | 1000+ integrations (fallback) | **NOT semver — pin to minor series** |
 | `faiss-cpu` | FAISS vector store (local) | Via `langchain-community`; use latest |
@@ -136,7 +136,7 @@ These packages have tighter compatibility requirements — use the latest availa
 
 | Package | Adds | Notes |
 |---------|------|-------|
-| `@langchain/tavily` | Tavily web search tool | Dedicated integration package; prefer latest |
+| `@langchain/tavily` | Tavily web search (`TavilySearch`) | Dedicated integration package; prefer latest |
 | `@langchain/community` | Broad set of community integrations | Use sparingly; prefer dedicated packages |
 | `@langchain/pinecone` | Pinecone vector store | Dedicated integration package; prefer latest |
 | `@langchain/qdrant` | Qdrant vector store | Dedicated integration package; prefer latest |
@@ -351,6 +351,29 @@ langchain-tavily==0.0.1
 langchain-tavily>=0.1
 ```
 </fix-community-tool-outdated>
+
+<fix-community-import-deprecated>
+Many tools that used to live in `langchain-community` now have dedicated packages with updated import paths. Always prefer the dedicated package import.
+
+```python
+# WRONG — deprecated community import path
+from langchain_community.tools.tavily_search import TavilySearchResults
+from langchain_community.tools import WikipediaQueryRun
+from langchain_community.vectorstores import Chroma
+from langchain_community.vectorstores import Pinecone
+
+# CORRECT — use dedicated package imports
+from langchain_tavily import TavilySearch                  # pip: langchain-tavily (TavilySearchResults is deprecated)
+from langchain_community.tools import WikipediaQueryRun  # no dedicated pkg yet
+from langchain_chroma import Chroma                       # pip: langchain-chroma
+from langchain_pinecone import PineconeVectorStore        # pip: langchain-pinecone
+```
+
+To find the current canonical import for any integration, search the integrations directory:
+https://python.langchain.com/docs/integrations/tools/
+
+Each entry shows the correct package and import path. If a dedicated package exists, use it — the community path may still work but is considered legacy.
+</fix-community-import-deprecated>
 
 <fix-core-not-installed>
 <typescript>

--- a/config/skills/langchain-fundamentals/SKILL.md
+++ b/config/skills/langchain-fundamentals/SKILL.md
@@ -35,7 +35,7 @@ result = agent.invoke({"messages": [("user", "Search for LangChain docs")]})
 <typescript>
 Create and invoke a basic agent with tools using createAgent.
 ```typescript
-import { createAgent } from "@langchain/langgraph/prebuilt";
+import { createAgent } from "langchain";
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 
@@ -72,8 +72,7 @@ const result = await agent.invoke({ messages: [["user", "Search for LangChain do
 | `tools` | List of tools | `[search, calculator]` |
 | `system_prompt` / `systemPrompt` | Agent instructions | `"You are a helpful assistant"` |
 | `checkpointer` | State persistence | `MemorySaver()` |
-| `middleware` | Processing hooks | `[human_in_the_loop_middleware]` |
-| `max_iterations` / `maxIterations` | Loop limit | `10` |
+| `middleware` | Processing hooks | `[HumanInTheLoopMiddleware]` (Python) / `[humanInTheLoopMiddleware({...})]` (TypeScript) |
 </create_agent>
 
 <ex-basic-agent>
@@ -107,7 +106,7 @@ print(result["messages"][-1].content)
 <typescript>
 Create a basic agent with a weather tool and invoke it with a user query.
 ```typescript
-import { createAgent } from "@langchain/langgraph/prebuilt";
+import { createAgent } from "langchain";
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 
@@ -158,7 +157,7 @@ result = agent.invoke({"messages": [{"role": "user", "content": "What's my name?
 <typescript>
 Add MemorySaver checkpointer to maintain conversation state across invocations.
 ```typescript
-import { createAgent } from "@langchain/langgraph/prebuilt";
+import { createAgent } from "langchain";
 import { MemorySaver } from "@langchain/langgraph";
 
 const checkpointer = new MemorySaver();
@@ -245,7 +244,8 @@ Middleware intercepts the agent loop to add human approval, error handling, logg
 <python>
 Require human approval before executing sensitive tools like delete operations.
 ```python
-from langchain.agents import create_agent, human_in_the_loop_middleware
+from langchain.agents import create_agent
+from langchain.agents.middleware import HumanInTheLoopMiddleware
 
 @tool
 def delete_record(record_id: str) -> str:
@@ -261,8 +261,8 @@ agent = create_agent(
     model="anthropic:claude-sonnet-4-5",
     tools=[delete_record, search],
     middleware=[
-        human_in_the_loop_middleware(
-            tools_requiring_approval=["delete_record"]
+        HumanInTheLoopMiddleware(
+            interrupt_on={"delete_record": True}
         )
     ],
 )
@@ -271,7 +271,7 @@ agent = create_agent(
 <typescript>
 Require human approval before executing sensitive tools like delete operations.
 ```typescript
-import { createAgent, humanInTheLoopMiddleware } from "@langchain/langgraph/prebuilt";
+import { createAgent, humanInTheLoopMiddleware } from "langchain";
 
 const deleteRecord = tool(
   async ({ recordId }) => {
@@ -302,7 +302,8 @@ const agent = createAgent({
 <python>
 Catch and handle tool errors gracefully with custom middleware.
 ```python
-from langchain.agents import create_agent, wrap_tool_call
+from langchain.agents import create_agent
+from langchain.agents.middleware import wrap_tool_call
 
 @wrap_tool_call
 async def error_handler(tool_call, handler):
@@ -324,17 +325,20 @@ agent = create_agent(
 <typescript>
 Catch and handle tool errors gracefully with custom middleware.
 ```typescript
-import { createAgent, wrapToolCall } from "@langchain/langgraph/prebuilt";
+import { createAgent, createMiddleware } from "langchain";
 
-const errorHandler = wrapToolCall(async (toolCall, handler) => {
-  try {
-    return await handler(toolCall);
-  } catch (error) {
-    return {
-      ...toolCall,
-      content: `Tool error: ${error}. Please try a different approach.`,
-    };
-  }
+const errorHandler = createMiddleware({
+  name: "ErrorHandler",
+  wrapToolCall: async (request, handler) => {
+    try {
+      return await handler(request);
+    } catch (error) {
+      return {
+        ...request.toolCall,
+        content: `Tool error: ${error}. Please try a different approach.`,
+      };
+    }
+  },
 });
 
 const agent = createAgent({
@@ -475,31 +479,29 @@ await agent.invoke({ messages: [{ role: "user", content: "What's my name?" }] },
 
 <fix-infinite-loop>
 <python>
-Set max_iterations to prevent runaway agent loops.
+Set recursion_limit in the invoke config to prevent runaway agent loops.
 ```python
 # WRONG: No iteration limit - could loop forever
-agent = create_agent(model="anthropic:claude-sonnet-4-5", tools=[search])
+result = agent.invoke({"messages": [("user", "Do research")]})
 
-# CORRECT: Set max_iterations
-agent = create_agent(
-    model="anthropic:claude-sonnet-4-5",
-    tools=[search],
-    max_iterations=10,  # Stop after 10 tool calls
+# CORRECT: Set recursion_limit in config
+result = agent.invoke(
+    {"messages": [("user", "Do research")]},
+    config={"recursion_limit": 10},  # Stop after 10 steps
 )
 ```
 </python>
 <typescript>
-Set maxIterations to prevent runaway agent loops.
+Set recursionLimit in the invoke config to prevent runaway agent loops.
 ```typescript
 // WRONG: No iteration limit
-const agent = createAgent({ model: "anthropic:claude-sonnet-4-5", tools: [search] });
+const result = await agent.invoke({ messages: [["user", "Do research"]] });
 
-// CORRECT: Set maxIterations
-const agent = createAgent({
-  model: "anthropic:claude-sonnet-4-5",
-  tools: [search],
-  maxIterations: 10, // Stop after 10 tool calls
-});
+// CORRECT: Set recursionLimit in config
+const result = await agent.invoke(
+  { messages: [["user", "Do research"]] },
+  { recursionLimit: 10 }, // Stop after 10 steps
+);
 ```
 </typescript>
 </fix-infinite-loop>

--- a/config/skills/langchain-output/SKILL.md
+++ b/config/skills/langchain-output/SKILL.md
@@ -12,7 +12,7 @@ Two critical patterns for production agents:
 **Key Concepts:**
 - **response_format**: Define expected output schema
 - **with_structured_output()**: Model method for direct structured output
-- **human_in_the_loop_middleware**: Pauses execution for human decisions
+- **HumanInTheLoopMiddleware**: Pauses execution for human decisions
 </overview>
 
 <when-to-use-structured-output>
@@ -177,7 +177,8 @@ class Person(BaseModel):
 <python>
 Set up an agent with HITL middleware that pauses before sending emails for approval.
 ```python
-from langchain.agents import create_agent, human_in_the_loop_middleware
+from langchain.agents import create_agent
+from langchain.agents.middleware import HumanInTheLoopMiddleware
 from langgraph.checkpoint.memory import MemorySaver
 from langchain.tools import tool
 
@@ -191,7 +192,7 @@ agent = create_agent(
     tools=[send_email],
     checkpointer=MemorySaver(),  # Required for HITL
     middleware=[
-        human_in_the_loop_middleware(
+        HumanInTheLoopMiddleware(
             interrupt_on={
                 "send_email": {"allowed_decisions": ["approve", "edit", "reject"]},
             }
@@ -326,7 +327,7 @@ agent = create_agent(
     tools=[send_email, read_email, delete_email],
     checkpointer=MemorySaver(),
     middleware=[
-        human_in_the_loop_middleware(
+        HumanInTheLoopMiddleware(
             interrupt_on={
                 "send_email": {"allowed_decisions": ["approve", "edit", "reject"]},
                 "delete_email": {"allowed_decisions": ["approve", "reject"]},  # No edit
@@ -421,13 +422,13 @@ class Data(BaseModel):
 HITL middleware requires a checkpointer to persist state.
 ```python
 # WRONG
-agent = create_agent(model="gpt-4", tools=[send_email], middleware=[human_in_the_loop_middleware({...})])
+agent = create_agent(model="gpt-4", tools=[send_email], middleware=[HumanInTheLoopMiddleware({...})])
 
 # CORRECT
 agent = create_agent(
     model="gpt-4", tools=[send_email],
     checkpointer=MemorySaver(),  # Required
-    middleware=[human_in_the_loop_middleware({...})]
+    middleware=[HumanInTheLoopMiddleware({...})]
 )
 ```
 </python>

--- a/config/skills/langchain-rag/SKILL.md
+++ b/config/skills/langchain-rag/SKILL.md
@@ -40,7 +40,7 @@ End-to-end RAG pipeline: load documents, split into chunks, embed, store, retrie
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from langchain_community.vectorstores import InMemoryVectorStore
 from langchain_text_splitters import RecursiveCharacterTextSplitter
-from langchain.schema import Document
+from langchain_core.documents import Document
 
 # 1. Load documents
 docs = [

--- a/config/skills/langgraph-execution/SKILL.md
+++ b/config/skills/langgraph-execution/SKILL.md
@@ -32,7 +32,7 @@ Build a ReAct agent that dynamically decides when to call tools based on model r
 ```python
 from langchain.tools import tool
 from langchain.chat_models import init_chat_model
-from langchain.messages import ToolMessage
+from langchain_core.messages import ToolMessage
 from langgraph.graph import StateGraph, START, END
 from typing import Annotated
 import operator
@@ -400,10 +400,10 @@ for chunk in graph.stream({"data": "test"}, stream_mode="custom"):
 <typescript>
 Emit custom progress updates from within nodes using the stream writer.
 ```typescript
-import { getStreamWriter } from "@langchain/langgraph";
+import { getWriter } from "@langchain/langgraph";
 
 const myNode = async (state: typeof State.State) => {
-  const writer = getStreamWriter();
+  const writer = getWriter();
   writer("Processing step 1...");
   // Do work
   writer("Complete!");

--- a/config/skills/langgraph-fundamentals/SKILL.md
+++ b/config/skills/langgraph-fundamentals/SKILL.md
@@ -76,7 +76,7 @@ Messages accumulate via reducer - new messages append, not overwrite.
 ```python
 from typing import Annotated
 import operator
-from langchain.messages import BaseMessage, HumanMessage, AIMessage
+from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
 
 class MessagesState(TypedDict):
     messages: Annotated[list[BaseMessage], operator.add]
@@ -374,7 +374,7 @@ const nodeA = async (state: typeof State.State) => {
 };
 
 const graph = new StateGraph(State)
-  .addNode("node_a", nodeA)
+  .addNode("node_a", nodeA, { ends: ["node_b", "node_c"] })
   .addNode("node_b", async () => ({ result: "B" }))
   .addNode("node_c", async () => ({ result: "C" }))
   .addEdge(START, "node_a")


### PR DESCRIPTION
## Summary
- Update Python imports to latest module paths
- Update TypeScript imports to latest module path
- Fix `Command` import path (`langgraph.types` instead of `langchain.schema`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)