### PR TITLE
fix: update outdated gpt-4 references to gpt-4.1

### DIFF
--- a/config/skills/deep-agents-memory/SKILL.md
+++ b/config/skills/deep-agents-memory/SKILL.md
@@ -180,7 +180,7 @@ def save_user_preference(key: str, value: str, runtime: ToolRuntime) -> str:
 store = InMemoryStore()
 
 agent = create_agent(
-    model="gpt-4",
+    model="gpt-4.1",
     tools=[get_user_preference, save_user_preference],
     store=store
 )

--- a/config/skills/langchain-middleware/SKILL.md
+++ b/config/skills/langchain-middleware/SKILL.md
@@ -32,7 +32,7 @@ def send_email(to: str, subject: str, body: str) -> str:
     return f"Email sent to {to}"
 
 agent = create_agent(
-    model="gpt-4",
+    model="gpt-4.1",
     tools=[send_email],
     checkpointer=MemorySaver(),  # Required for HITL
     middleware=[
@@ -207,11 +207,11 @@ agent = create_agent(
 HITL middleware requires a checkpointer to persist state.
 ```python
 # WRONG
-agent = create_agent(model="gpt-4", tools=[send_email], middleware=[HumanInTheLoopMiddleware({...})])
+agent = create_agent(model="gpt-4.1", tools=[send_email], middleware=[HumanInTheLoopMiddleware({...})])
 
 # CORRECT
 agent = create_agent(
-    model="gpt-4", tools=[send_email],
+    model="gpt-4.1", tools=[send_email],
     checkpointer=MemorySaver(),  # Required
     middleware=[HumanInTheLoopMiddleware({...})]
 )

--- a/config/skills/langchain-rag/SKILL.md
+++ b/config/skills/langchain-rag/SKILL.md
@@ -60,7 +60,7 @@ vectorstore = InMemoryVectorStore.from_documents(splits, embeddings)
 retriever = vectorstore.as_retriever(k=4)
 
 # 5. Use in RAG
-model = ChatOpenAI(model="gpt-4")
+model = ChatOpenAI(model="gpt-4.1")
 query = "What is RAG?"
 relevant_docs = retriever.invoke(query)
 
@@ -97,7 +97,7 @@ const vectorstore = await MemoryVectorStore.fromDocuments(splits, embeddings);
 const retriever = vectorstore.asRetriever({ k: 4 });
 
 // 5. Use in RAG
-const model = new ChatOpenAI({ model: "gpt-4" });
+const model = new ChatOpenAI({ model: "gpt-4.1" });
 const query = "What is RAG?";
 const relevantDocs = await retriever.invoke(query);
 


### PR DESCRIPTION
Update model references from `gpt-4` to `gpt-4.1` in langchain-middleware, langchain-rag, and deep-agents-memory skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)