### PR TITLE
fix: use LANGSMITH_ENDPOINT env var in evaluator scripts

### DIFF
--- a/config/skills/langsmith-evaluator/scripts/upload_evaluators.py
+++ b/config/skills/langsmith-evaluator/scripts/upload_evaluators.py
@@ -19,7 +19,7 @@ console = Console()
 
 # Configuration
 LANGSMITH_API_KEY = os.getenv("LANGSMITH_API_KEY")
-LANGSMITH_API_URL = os.getenv("LANGSMITH_API_URL", "https://api.smith.langchain.com")
+LANGSMITH_API_URL = os.getenv("LANGSMITH_ENDPOINT", "https://api.smith.langchain.com")
 LANGSMITH_WORKSPACE_ID = os.getenv("LANGSMITH_WORKSPACE_ID")
 
 if not LANGSMITH_API_KEY:

--- a/config/skills/langsmith-evaluator/scripts/upload_evaluators.ts
+++ b/config/skills/langsmith-evaluator/scripts/upload_evaluators.ts
@@ -22,7 +22,7 @@ dotenv.config();
 
 export const LANGSMITH_API_KEY = process.env.LANGSMITH_API_KEY;
 export const LANGSMITH_API_URL =
-  process.env.LANGSMITH_API_URL || "https://api.smith.langchain.com";
+  process.env.LANGSMITH_ENDPOINT || "https://api.smith.langchain.com";
 export const LANGSMITH_WORKSPACE_ID = process.env.LANGSMITH_WORKSPACE_ID;
 
 // Only validate API key when running as CLI (not when imported for testing)


### PR DESCRIPTION
Upload evaluator scripts (Python + TypeScript) were reading `LANGSMITH_API_URL` instead of `LANGSMITH_ENDPOINT`. 