### PR TITLE
fix: lowercase skill names for Agent Skills spec compliance

### DIFF
--- a/config/skills/deep-agents-core/SKILL.md
+++ b/config/skills/deep-agents-core/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Deep Agents Core
+name: deep-agents-core
 description: "INVOKE THIS SKILL when building ANY Deep Agents application. Covers create_deep_agent(), harness architecture, SKILL.md format, and configuration options."
 ---
 

--- a/config/skills/deep-agents-memory/SKILL.md
+++ b/config/skills/deep-agents-memory/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Deep Agents Memory & Filesystem
+name: deep-agents-memory
 description: "INVOKE THIS SKILL when your Deep Agent needs memory, persistence, or filesystem access. Covers StateBackend (ephemeral), StoreBackend (persistent), FilesystemMiddleware, and CompositeBackend for routing."
 ---
 

--- a/config/skills/deep-agents-orchestration/SKILL.md
+++ b/config/skills/deep-agents-orchestration/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Deep Agents Orchestration
+name: deep-agents-orchestration
 description: "INVOKE THIS SKILL when using subagents, task planning, or human approval in Deep Agents. Covers SubAgentMiddleware, TodoList for planning, and HITL interrupts."
 ---
 

--- a/config/skills/framework-selection/SKILL.md
+++ b/config/skills/framework-selection/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Framework Selection
+name: framework-selection
 description: "INVOKE THIS SKILL at the START of any LangChain/LangGraph/Deep Agents project, before writing any agent code. Determines which framework layer is right for the task: LangChain, LangGraph, Deep Agents, or a combination. Must be consulted before other agent skills."
 ---
 

--- a/config/skills/langchain-dependencies/SKILL.md
+++ b/config/skills/langchain-dependencies/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: LangChain Dependencies
+name: langchain-dependencies
 description: "INVOKE THIS SKILL when setting up a new project or when asked about package versions, installation, or dependency management for LangChain, LangGraph, LangSmith, or Deep Agents. Covers required packages, minimum versions, environment requirements, versioning best practices, and common community tool packages for both Python and TypeScript."
 ---
 

--- a/config/skills/langchain-fundamentals/SKILL.md
+++ b/config/skills/langchain-fundamentals/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: LangChain Fundamentals
+name: langchain-fundamentals
 description: Create LangChain agents with create_agent, define tools, and use middleware for human-in-the-loop and error handling.
 ---
 

--- a/config/skills/langchain-middleware/SKILL.md
+++ b/config/skills/langchain-middleware/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: LangChain Middleware & HITL
+name: langchain-middleware
 description: "INVOKE THIS SKILL when you need human-in-the-loop approval, custom middleware, or structured output. Covers HumanInTheLoopMiddleware for human approval of dangerous tool calls, creating custom middleware with hooks, Command resume patterns, and structured output with Pydantic/Zod."
 ---
 

--- a/config/skills/langchain-rag/SKILL.md
+++ b/config/skills/langchain-rag/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: LangChain RAG Pipeline
+name: langchain-rag
 description: "INVOKE THIS SKILL when building ANY retrieval-augmented generation (RAG) system. Covers document loaders, RecursiveCharacterTextSplitter, embeddings (OpenAI), and vector stores (Chroma, FAISS, Pinecone)."
 ---
 

--- a/config/skills/langgraph-fundamentals/SKILL.md
+++ b/config/skills/langgraph-fundamentals/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: LangGraph Fundamentals
+name: langgraph-fundamentals
 description: "INVOKE THIS SKILL when writing ANY LangGraph code. Covers StateGraph, state schemas, nodes, edges, Command, Send, invoke, streaming, and error handling."
 ---
 

--- a/config/skills/langgraph-human-in-the-loop/SKILL.md
+++ b/config/skills/langgraph-human-in-the-loop/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: LangGraph Human-in-the-Loop
+name: langgraph-human-in-the-loop
 description: "INVOKE THIS SKILL when implementing human-in-the-loop patterns, pausing for approval, or handling errors in LangGraph. Covers interrupt(), Command(resume=...), approval/validation workflows, and the 4-tier error handling strategy."
 ---
 

--- a/config/skills/langgraph-persistence/SKILL.md
+++ b/config/skills/langgraph-persistence/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: LangGraph Persistence & Memory
+name: langgraph-persistence
 description: "INVOKE THIS SKILL when your LangGraph needs to persist state, remember conversations, travel through history, or configure subgraph checkpointer scoping. Covers checkpointers, thread_id, time travel, Store, and subgraph persistence modes."
 ---
 

--- a/config/skills/langsmith-dataset/SKILL.md
+++ b/config/skills/langsmith-dataset/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: LangSmith Dataset
+name: langsmith-dataset
 description: "INVOKE THIS SKILL when creating evaluation datasets from trace OR uploading datasets to LangSmith OR querying datasets. Covers dataset types (final_response, single_step, trajectory, RAG) and LangSmith upload. Contains helper scripts to use or refer to."
 ---
 

--- a/config/skills/langsmith-evaluator/SKILL.md
+++ b/config/skills/langsmith-evaluator/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: LangSmith Evaluators
+name: langsmith-evaluator
 description: "INVOKE THIS SKILL when building evaluation pipelines for LangSmith. Covers three core components: (1) Creating Evaluators - LLM-as-Judge, custom code; (2) Defining Run Functions - how to capture outputs and trajectories from your agent; (3) Running Evaluations - locally with evaluate() or auto-run via LangSmith. Contains helper scripts."
 ---
 

--- a/config/skills/langsmith-trace/SKILL.md
+++ b/config/skills/langsmith-trace/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Langsmith Traces
+name: langsmith-trace
 description: "INVOKE THIS SKILL when working with LangSmith tracing OR querying traces. Covers adding tracing to applications and querying/exporting trace data. Contains helper scripts to use or refer to"
 ---
 


### PR DESCRIPTION
## Summary
- Lowercases the `name` frontmatter field in all 14 SKILL.md files to match their directory names
- This is required by the [Agent Skills specification](https://agentskills.io/specification): names must be lowercase alphanumeric + hyphens, and must match the parent directory name
- Enables compatibility with [skills.sh](https://skills.sh) and `npx skills add`

## Test plan
- [x] Verified all 14 SKILL.md `name` fields now match their directory names
- [x] Tested `npx skills add` from a temp directory — all 14 skills discovered and installed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)