### PR TITLE
feat: add TypeScript examples back to langsmith-evaluator skill

### DIFF
--- a/config/skills/langsmith-evaluator/SKILL.md
+++ b/config/skills/langsmith-evaluator/SKILL.md
@@ -91,6 +91,32 @@ async def accuracy_evaluator(run, example):
     return {"score": 1 if grade["is_accurate"] else 0, "comment": grade["reasoning"]}
 ```
 </python>
+
+<typescript>
+```javascript
+import OpenAI from "openai";
+
+const openai = new OpenAI();
+
+async function accuracyEvaluator(run, example) {
+  const runOutputs = run.outputs ?? {};
+  const exampleOutputs = example.outputs ?? {};
+
+  const response = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    temperature: 0,
+    response_format: { type: "json_object" },
+    messages: [
+      { role: "system", content: 'Respond with JSON: {"is_accurate": boolean, "reasoning": string}' },
+      { role: "user", content: `Expected: ${JSON.stringify(exampleOutputs)}\nActual: ${JSON.stringify(runOutputs)}\nIs this accurate?` }
+    ]
+  });
+
+  const grade = JSON.parse(response.choices[0].message.content);
+  return { score: grade.is_accurate ? 1 : 0, comment: grade.reasoning };
+}
+```
+</typescript>
 </llm_judge>
 
 <code_evaluators>
@@ -115,6 +141,22 @@ def trajectory_evaluator(run, example):
     return {"score": 1 if actual == expected else 0, "comment": f"Expected {expected}, got {actual}"}
 ```
 </python>
+
+<typescript>
+```javascript
+function trajectoryEvaluator(run, example) {
+  const runOutputs = run.outputs ?? {};
+  const exampleOutputs = example.outputs ?? {};
+  // IMPORTANT: Replace these placeholders with your actual field names
+  // 1. Query your LangSmith trace to see what fields exist in run outputs
+  // 2. Check your dataset schema for expected field names
+  const actual = runOutputs.YOUR_TRAJECTORY_FIELD ?? [];
+  const expected = exampleOutputs.YOUR_EXPECTED_FIELD ?? [];
+  const match = JSON.stringify(actual) === JSON.stringify(expected);
+  return { score: match ? 1 : 0, comment: `Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}` };
+}
+```
+</typescript>
 </code_evaluators>
 
 <run_functions>
@@ -134,6 +176,7 @@ Before writing evaluators, you MUST test your run function and inspect the actua
 
 **Try your hardest to match your run function output to your dataset schema.** This makes evaluators simple and reusable. If matching isn't possible, your evaluator must know how to extract and compare the right fields from each side.
 
+<python>
 ```python
 def run_agent(inputs: dict) -> dict:
     result = your_agent.run(inputs)
@@ -142,6 +185,19 @@ def run_agent(inputs: dict) -> dict:
     print(f"DEBUG - value: {result}")
     return {"output": result}  # Adjust to match your dataset schema
 ```
+</python>
+
+<typescript>
+```javascript
+async function runAgent(inputs) {
+  const result = await yourAgent.invoke(inputs);
+  // ALWAYS inspect output shape first
+  console.log("DEBUG - type:", typeof result, "keys:", Object.keys(result));
+  console.log("DEBUG - value:", result);
+  return { output: result };  // Adjust to match your dataset schema
+}
+```
+</typescript>
 
 ### Capturing Trajectories
 
@@ -265,6 +321,7 @@ npx tsx upload_evaluators.ts delete "Trajectory Match"
 
 **Uploaded evaluators** auto-run when you run experiments - no code needed. **Local evaluators** are passed directly for development/testing.
 
+<python>
 ```python
 from langsmith import evaluate
 
@@ -274,6 +331,26 @@ results = evaluate(run_agent, data="My Dataset", experiment_prefix="eval-v1")
 # Or pass local evaluators for testing
 results = evaluate(run_agent, data="My Dataset", evaluators=[my_evaluator], experiment_prefix="eval-v1")
 ```
+</python>
+
+<typescript>
+```javascript
+import { evaluate } from "langsmith/evaluation";
+
+// Uploaded evaluators run automatically
+const results = await evaluate(runAgent, {
+  data: "My Dataset",
+  experimentPrefix: "eval-v1",
+});
+
+// Or pass local evaluators for testing
+const results = await evaluate(runAgent, {
+  data: "My Dataset",
+  evaluators: [myEvaluator],
+  experimentPrefix: "eval-v1",
+});
+```
+</typescript>
 </running_evaluations>
 
 <troubleshooting>
@@ -285,10 +362,11 @@ results = evaluate(run_agent, data="My Dataset", evaluators=[my_evaluator], expe
 
 **Field name mismatch:** Your run function output must match dataset schema exactly. Inspect dataset first with `client.read_example(example_id)`.
 
-**RunTree vs dict (Python):** Local `evaluate()` passes `RunTree`, uploaded evaluators receive `dict`. Handle both:
+**RunTree vs dict (Python only):** Local `evaluate()` passes `RunTree`, uploaded evaluators receive `dict`. Handle both:
 ```python
 run_outputs = run.outputs if hasattr(run, "outputs") else run.get("outputs", {}) or {}
 ```
+TypeScript always uses attribute access: `run.outputs?.field`
 </troubleshooting>
 
 <resources>


### PR DESCRIPTION
## Summary
- Re-adds TypeScript equivalents for evaluator code examples that were removed in the v1+ update (`0da7364`)
- Adds TS examples for:
  - LLM-as-Judge evaluator (OpenAI SDK with JSON mode)
  - Custom code evaluator (trajectory validation)
  - Run function (basic agent invocation)
  - `evaluate()` usage (langsmith/evaluation)
- Adds TS note to troubleshooting section
- Skill goes from 298 to 376 lines (still under 500 recommendation)

## Test plan
- [x] Verified all TS examples follow current patterns (not the old pre-v1 style)
- [x] TS examples use attribute access (`run.outputs?.field`) consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)