### PR TITLE
docs: add spacing before code fences

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,17 @@ These skills can be installed via [`npx skills`](https://github.com/vercel-labs/
 Using [`npx skills`](https://github.com/vercel-labs/skills):
 
 **Local** (current project):
+
 ```bash
 npx skills add langchain-ai/langchain-skills --skill '*' --yes
 ```
-
 **Global** (all projects):
+
 ```bash
 npx skills add langchain-ai/langchain-skills --skill '*' --yes --global
 ```
-
 To link skills to a specific agent (e.g. Claude Code):
+
 ```bash
 npx skills add langchain-ai/langchain-skills --agent claude-code --skill '*' --yes --global
 ```

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -28,6 +28,7 @@ This project uses skills that contain up-to-date patterns and working reference 
 ## Environment Setup
 
 Required environment variables:
+
 ```bash
 OPENAI_API_KEY=<your-key>  # For OpenAI models
 ANTHROPIC_API_KEY=<your-key>  # For Anthropic models

--- a/config/skills/deep-agents-core/SKILL.md
+++ b/config/skills/deep-agents-core/SKILL.md
@@ -43,6 +43,7 @@ The agent harness provides these capabilities automatically - you configure, not
 <ex-basic-agent>
 <python>
 Create a basic deep agent with a custom tool and invoke it with a user message.
+
 ```python
 from deepagents import create_deep_agent
 from langchain.tools import tool
@@ -66,6 +67,7 @@ result = agent.invoke({
 </python>
 <typescript>
 Create a basic deep agent with a custom tool and invoke it with a user message.
+
 ```typescript
 import { createDeepAgent } from "deepagents";
 import { tool } from "@langchain/core/tools";
@@ -93,6 +95,7 @@ const result = await agent.invoke({
 <ex-full-configuration>
 <python>
 Configure a deep agent with all available options including subagents, skills, and persistence.
+
 ```python
 from deepagents import create_deep_agent
 from deepagents.backends import FilesystemBackend
@@ -115,6 +118,7 @@ agent = create_deep_agent(
 </python>
 <typescript>
 Configure a deep agent with all available options including subagents, skills, and persistence.
+
 ```typescript
 import { createDeepAgent, FilesystemBackend } from "deepagents";
 import { MemorySaver, InMemoryStore } from "@langchain/langgraph";
@@ -151,6 +155,7 @@ Every deep agent has access to:
 Skills use **progressive disclosure** - agents only load content when relevant.
 
 ### Directory Structure
+
 ```
 skills/
 └── my-skill/
@@ -160,6 +165,7 @@ skills/
 ```
 
 ### SKILL.md Format
+
 ```markdown
 ---
 name: my-skill
@@ -193,6 +199,7 @@ Step-by-step guidance for the agent.
 <ex-skills-with-filesystem-backend>
 <python>
 Set up an agent with skills directory and filesystem backend for on-demand skill loading.
+
 ```python
 from deepagents import create_deep_agent
 from deepagents.backends import FilesystemBackend
@@ -211,6 +218,7 @@ result = agent.invoke({
 </python>
 <typescript>
 Set up an agent with skills directory and filesystem backend for on-demand skill loading.
+
 ```typescript
 import { createDeepAgent, FilesystemBackend } from "deepagents";
 import { MemorySaver } from "@langchain/langgraph";
@@ -231,6 +239,7 @@ const result = await agent.invoke({
 <ex-skills-with-store-backend>
 <python>
 Load skill content into a Store backend for environments without filesystem access.
+
 ```python
 from deepagents import create_deep_agent
 from deepagents.backends import StoreBackend
@@ -263,6 +272,7 @@ agent = create_deep_agent(
 </ex-skills-with-store-backend>
 
 <boundaries>
+
 ### What Agents CAN Configure
 
 - Model selection and parameters
@@ -282,6 +292,7 @@ agent = create_deep_agent(
 <fix-checkpointer-for-interrupts>
 <python>
 Interrupts require a checkpointer.
+
 ```python
 # WRONG
 agent = create_deep_agent(interrupt_on={"write_file": True})
@@ -292,6 +303,7 @@ agent = create_deep_agent(interrupt_on={"write_file": True}, checkpointer=Memory
 </python>
 <typescript>
 Interrupts require a checkpointer.
+
 ```typescript
 // WRONG
 const agent = await createDeepAgent({ interruptOn: { write_file: true } });
@@ -305,6 +317,7 @@ const agent = await createDeepAgent({ interruptOn: { write_file: true }, checkpo
 <fix-store-for-memory>
 <python>
 StoreBackend requires a Store instance for persistent memory across threads.
+
 ```python
 # WRONG
 agent = create_deep_agent(backend=lambda rt: StoreBackend(rt))
@@ -315,6 +328,7 @@ agent = create_deep_agent(backend=lambda rt: StoreBackend(rt), store=InMemorySto
 </python>
 <typescript>
 StoreBackend requires a Store instance for persistent memory across threads.
+
 ```typescript
 // WRONG
 const agent = await createDeepAgent({ backend: (config) => new StoreBackend(config) });
@@ -328,6 +342,7 @@ const agent = await createDeepAgent({ backend: (config) => new StoreBackend(conf
 <fix-thread-id-for-conversations>
 <python>
 Use consistent thread_id to maintain conversation context across invocations.
+
 ```python
 # WRONG: Each invocation is isolated
 agent.invoke({"messages": [{"role": "user", "content": "Hi"}]})
@@ -341,6 +356,7 @@ agent.invoke({"messages": [...]}, config=config)
 </python>
 <typescript>
 Use consistent thread_id to maintain conversation context across invocations.
+
 ```typescript
 // WRONG: Each invocation is isolated
 await agent.invoke({ messages: [{ role: "user", content: "Hi" }] });
@@ -355,6 +371,7 @@ await agent.invoke({ messages: [...] }, config);
 </fix-thread-id-for-conversations>
 
 <fix-frontmatter-required>
+
 ```markdown
 # WRONG: Missing frontmatter in SKILL.md
 # My Skill
@@ -373,6 +390,7 @@ This is my skill...
 <fix-backend-for-skills>
 <python>
 Skills require a proper backend to load from the filesystem.
+
 ```python
 # WRONG: Skills won't load without proper backend
 agent = create_deep_agent(skills=["./skills/"])
@@ -388,6 +406,7 @@ agent = create_deep_agent(
 
 <fix-specific-skill-descriptions>
 Use specific descriptions to help agents decide when to use a skill.
+
 ```markdown
 # WRONG: Vague description
 ---
@@ -406,6 +425,7 @@ description: Python testing best practices with pytest fixtures, mocking, and as
 <fix-subagent-skills>
 <python>
 Skills are not inherited by subagents - provide them explicitly.
+
 ```python
 # WRONG: Custom subagents don't inherit skills
 agent = create_deep_agent(

--- a/config/skills/deep-agents-memory/SKILL.md
+++ b/config/skills/deep-agents-memory/SKILL.md
@@ -27,6 +27,7 @@ FilesystemMiddleware provides tools: `ls`, `read_file`, `write_file`, `edit_file
 <ex-default-state-backend>
 <python>
 Default StateBackend stores files ephemerally within a thread.
+
 ```python
 from deepagents import create_deep_agent
 
@@ -39,6 +40,7 @@ result = agent.invoke({
 </python>
 <typescript>
 Default StateBackend stores files ephemerally within a thread.
+
 ```typescript
 import { createDeepAgent } from "deepagents";
 
@@ -54,6 +56,7 @@ const result = await agent.invoke({
 <ex-composite-backend-for-hybrid>
 <python>
 Configure CompositeBackend to route paths to different storage backends.
+
 ```python
 from deepagents import create_deep_agent
 from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
@@ -74,6 +77,7 @@ agent = create_deep_agent(backend=composite_backend, store=store)
 </python>
 <typescript>
 Configure CompositeBackend to route paths to different storage backends.
+
 ```typescript
 import { createDeepAgent, CompositeBackend, StateBackend, StoreBackend } from "deepagents";
 import { InMemoryStore } from "@langchain/langgraph";
@@ -97,6 +101,7 @@ const agent = await createDeepAgent({
 <ex-cross-session-memory>
 <python>
 Files in /memories/ persist across threads via StoreBackend routing.
+
 ```python
 # Using CompositeBackend from previous example
 config1 = {"configurable": {"thread_id": "thread-1"}}
@@ -109,6 +114,7 @@ agent.invoke({"messages": [{"role": "user", "content": "Read /memories/style.txt
 </python>
 <typescript>
 Files in /memories/ persist across threads via StoreBackend routing.
+
 ```typescript
 // Using CompositeBackend from previous example
 const config1 = { configurable: { thread_id: "thread-1" } };
@@ -124,6 +130,7 @@ await agent.invoke({ messages: [{ role: "user", content: "Read /memories/style.t
 <ex-filesystem-backend-local-dev>
 <python>
 Use FilesystemBackend for local development with real disk access and human-in-the-loop.
+
 ```python
 from deepagents import create_deep_agent
 from deepagents.backends import FilesystemBackend
@@ -140,6 +147,7 @@ agent = create_deep_agent(
 </python>
 <typescript>
 Use FilesystemBackend for local development with real disk access and human-in-the-loop.
+
 ```typescript
 import { createDeepAgent, FilesystemBackend } from "deepagents";
 import { MemorySaver } from "@langchain/langgraph";
@@ -158,6 +166,7 @@ const agent = await createDeepAgent({
 <ex-store-in-custom-tools>
 <python>
 Access the store directly in custom tools for long-term memory operations.
+
 ```python
 from langchain.tools import tool, ToolRuntime
 from langchain.agents import create_agent
@@ -206,6 +215,7 @@ agent = create_agent(
 <fix-storebackend-requires-store>
 <python>
 StoreBackend requires a store instance.
+
 ```python
 # WRONG
 agent = create_deep_agent(backend=lambda rt: StoreBackend(rt))
@@ -216,6 +226,7 @@ agent = create_deep_agent(backend=lambda rt: StoreBackend(rt), store=InMemorySto
 </python>
 <typescript>
 StoreBackend requires a store instance.
+
 ```typescript
 // WRONG
 const agent = await createDeepAgent({ backend: (c) => new StoreBackend(c) });
@@ -229,6 +240,7 @@ const agent = await createDeepAgent({ backend: (c) => new StoreBackend(c), store
 <fix-statebackend-files-dont-persist>
 <python>
 StateBackend files are thread-scoped - use same thread_id or StoreBackend for cross-thread access.
+
 ```python
 # WRONG: thread-2 can't read file from thread-1
 agent.invoke({"messages": [...]}, config={"configurable": {"thread_id": "thread-1"}})  # Write
@@ -237,6 +249,7 @@ agent.invoke({"messages": [...]}, config={"configurable": {"thread_id": "thread-
 </python>
 <typescript>
 StateBackend files are thread-scoped - use same thread_id or StoreBackend for cross-thread access.
+
 ```typescript
 // WRONG: thread-2 can't read file from thread-1
 await agent.invoke({ messages: [...] }, { configurable: { thread_id: "thread-1" } });  // Write
@@ -248,6 +261,7 @@ await agent.invoke({ messages: [...] }, { configurable: { thread_id: "thread-2" 
 <fix-path-prefix-for-persistence>
 <python>
 Path must match CompositeBackend route prefix for persistence.
+
 ```python
 # With routes={"/memories/": StoreBackend(rt)}:
 agent.invoke(...)  # /prefs.txt -> ephemeral (no match)
@@ -256,6 +270,7 @@ agent.invoke(...)  # /memories/prefs.txt -> persistent (matches route)
 </python>
 <typescript>
 Path must match CompositeBackend route prefix for persistence.
+
 ```typescript
 // With routes: { "/memories/": StoreBackend }:
 await agent.invoke(...);  // /prefs.txt -> ephemeral (no match)
@@ -267,6 +282,7 @@ await agent.invoke(...);  // /memories/prefs.txt -> persistent (matches route)
 <fix-production-store>
 <python>
 Use PostgresStore for production (InMemoryStore lost on restart).
+
 ```python
 # WRONG                              # CORRECT
 store = InMemoryStore()              store = PostgresStore(connection_string="postgresql://...")
@@ -274,6 +290,7 @@ store = InMemoryStore()              store = PostgresStore(connection_string="po
 </python>
 <typescript>
 Use PostgresStore for production (InMemoryStore lost on restart).
+
 ```typescript
 // WRONG                                    // CORRECT
 const store = new InMemoryStore();          const store = new PostgresStore({ connectionString: "..." });
@@ -284,6 +301,7 @@ const store = new InMemoryStore();          const store = new PostgresStore({ co
 <fix-filesystem-backend-needs-virtual-mode>
 <python>
 Enable virtual_mode=True to restrict path access (prevents ../ and ~/ escapes).
+
 ```python
 backend = FilesystemBackend(root_dir="/project", virtual_mode=True)  # Secure
 ```
@@ -293,6 +311,7 @@ backend = FilesystemBackend(root_dir="/project", virtual_mode=True)  # Secure
 <fix-longest-prefix-match>
 <python>
 CompositeBackend matches longest prefix first.
+
 ```python
 routes = {"/mem/": StoreBackend(rt), "/mem/temp/": StateBackend(rt)}
 # /mem/file.txt -> StoreBackend, /mem/temp/file.txt -> StateBackend (longer match)

--- a/config/skills/deep-agents-orchestration/SKILL.md
+++ b/config/skills/deep-agents-orchestration/SKILL.md
@@ -36,6 +36,7 @@ Main agent has `task` tool -> creates fresh subagent -> subagent executes autono
 <ex-custom-subagents>
 <python>
 Create a custom "researcher" subagent with specialized tools for academic paper search.
+
 ```python
 from deepagents import create_deep_agent
 from langchain.tools import tool
@@ -61,6 +62,7 @@ agent = create_deep_agent(
 </python>
 <typescript>
 Create a custom "researcher" subagent with specialized tools for academic paper search.
+
 ```typescript
 import { createDeepAgent } from "deepagents";
 import { tool } from "@langchain/core/tools";
@@ -90,6 +92,7 @@ const agent = await createDeepAgent({
 <ex-subagent-with-hitl>
 <python>
 Configure a subagent with HITL approval for sensitive operations.
+
 ```python
 from deepagents import create_deep_agent
 from langgraph.checkpoint.memory import MemorySaver
@@ -113,6 +116,7 @@ agent = create_deep_agent(
 <fix-subagents-are-stateless>
 <python>
 Subagents are stateless - provide complete instructions in a single call.
+
 ```python
 # WRONG: Subagents don't remember previous calls
 # task(agent='research', instruction='Find data')
@@ -124,6 +128,7 @@ Subagents are stateless - provide complete instructions in a single call.
 </python>
 <typescript>
 Subagents are stateless - provide complete instructions in a single call.
+
 ```typescript
 // WRONG: Subagents don't remember previous calls
 // task research: Find data
@@ -138,6 +143,7 @@ Subagents are stateless - provide complete instructions in a single call.
 <fix-custom-subagents-dont-inherit-skills>
 <python>
 Custom subagents don't inherit skills from the main agent.
+
 ```python
 # WRONG: Custom subagent won't have main agent's skills
 agent = create_deep_agent(
@@ -168,6 +174,7 @@ agent = create_deep_agent(
 </when-to-use-todolist>
 
 <todolist-tool>
+
 ```
 write_todos(todos: list[dict]) -> None
 ```
@@ -180,6 +187,7 @@ Each todo item has:
 <ex-todolist-usage>
 <python>
 Invoke an agent that automatically creates a todo list for a multi-step task.
+
 ```python
 from deepagents import create_deep_agent
 
@@ -200,6 +208,7 @@ result = agent.invoke({
 </python>
 <typescript>
 Invoke an agent that automatically creates a todo list for a multi-step task.
+
 ```typescript
 import { createDeepAgent } from "deepagents";
 
@@ -215,6 +224,7 @@ const result = await agent.invoke({
 <ex-access-todo-state>
 <python>
 Access the todo list from the agent's final state after invocation.
+
 ```python
 result = agent.invoke({...}, config={"configurable": {"thread_id": "session-1"}})
 
@@ -229,6 +239,7 @@ for todo in todos:
 <fix-todolist-requires-thread-id>
 <python>
 Todo list state requires a thread_id for persistence across invocations.
+
 ```python
 # WRONG: Fresh state each time without thread_id
 agent.invoke({"messages": [...]})
@@ -256,6 +267,7 @@ agent.invoke({"messages": [...]}, config=config)  # Todos preserved
 <ex-hitl-setup>
 <python>
 Configure which tools require human approval before execution.
+
 ```python
 from deepagents import create_deep_agent
 from langgraph.checkpoint.memory import MemorySaver
@@ -272,6 +284,7 @@ agent = create_deep_agent(
 </python>
 <typescript>
 Configure which tools require human approval before execution.
+
 ```typescript
 import { createDeepAgent } from "deepagents";
 import { MemorySaver } from "@langchain/langgraph";
@@ -291,6 +304,7 @@ const agent = await createDeepAgent({
 <ex-approval-workflow>
 <python>
 Complete workflow: trigger an interrupt, check state, approve action, and resume execution.
+
 ```python
 from deepagents import create_deep_agent
 from langgraph.checkpoint.memory import MemorySaver
@@ -319,6 +333,7 @@ result = agent.invoke(Command(resume={"decisions": [{"type": "approve"}]}), conf
 </python>
 <typescript>
 Complete workflow: trigger an interrupt, check state, approve action, and resume execution.
+
 ```typescript
 import { createDeepAgent } from "deepagents";
 import { MemorySaver, Command } from "@langchain/langgraph";
@@ -352,6 +367,7 @@ result = await agent.invoke(
 <ex-reject-with-feedback>
 <python>
 Reject a pending action with feedback, prompting the agent to try a different approach.
+
 ```python
 result = agent.invoke(
     Command(resume={"decisions": [{"type": "reject", "message": "Run tests first"}]}),
@@ -361,6 +377,7 @@ result = agent.invoke(
 </python>
 <typescript>
 Reject a pending action with feedback, prompting the agent to try a different approach.
+
 ```typescript
 const result = await agent.invoke(
   new Command({ resume: { decisions: [{ type: "reject", message: "Run tests first" }] } }),
@@ -373,6 +390,7 @@ const result = await agent.invoke(
 <ex-edit-before-execution>
 <python>
 Edit the proposed action arguments before allowing execution.
+
 ```python
 result = agent.invoke(
     Command(resume={"decisions": [{
@@ -407,6 +425,7 @@ result = agent.invoke(
 <fix-checkpointer-required>
 <python>
 Checkpointer is required when using interrupt_on for HITL workflows.
+
 ```python
 # WRONG
 agent = create_deep_agent(interrupt_on={"write_file": True})
@@ -417,6 +436,7 @@ agent = create_deep_agent(interrupt_on={"write_file": True}, checkpointer=Memory
 </python>
 <typescript>
 Checkpointer is required when using interruptOn for HITL workflows.
+
 ```typescript
 // WRONG
 const agent = await createDeepAgent({ interruptOn: { write_file: true } });
@@ -430,6 +450,7 @@ const agent = await createDeepAgent({ interruptOn: { write_file: true }, checkpo
 <fix-thread-id-required-for-resumption>
 <python>
 A consistent thread_id is required to resume interrupted workflows.
+
 ```python
 # WRONG: Can't resume without thread_id
 agent.invoke({"messages": [...]})
@@ -443,6 +464,7 @@ agent.invoke(Command(resume={"decisions": [{"type": "approve"}]}), config=config
 </python>
 <typescript>
 A consistent thread_id is required to resume interrupted workflows.
+
 ```typescript
 // WRONG: Can't resume without thread_id
 await agent.invoke({ messages: [...] });
@@ -459,6 +481,7 @@ await agent.invoke(new Command({ resume: { decisions: [{ type: "approve" }] } })
 <fix-interrupt-checks-between-invocations>
 <python>
 Interrupts happen BETWEEN invoke() calls, not mid-execution.
+
 ```python
 result = agent.invoke({...}, config=config)       # Step 1: triggers interrupt
 if "__interrupt__" in result:                      # Step 2: check for interrupt

--- a/config/skills/langchain-dependencies/SKILL.md
+++ b/config/skills/langchain-dependencies/SKILL.md
@@ -153,6 +153,7 @@ These packages have tighter compatibility requirements — use the latest availa
 <ex-langgraph-python>
 <python>
 Minimal dependency set for a LangGraph project (provider-agnostic).
+
 ```
 # requirements.txt
 langchain>=1.0,<2.0
@@ -171,6 +172,7 @@ langsmith>=0.3.0
 <ex-langgraph-typescript>
 <typescript>
 Minimal package.json dependencies for a LangGraph project (provider-agnostic).
+
 ```json
 {
   "dependencies": {
@@ -187,6 +189,7 @@ Minimal package.json dependencies for a LangGraph project (provider-agnostic).
 <ex-deepagents-python>
 <python>
 Minimal dependency set for a Deep Agents project (provider-agnostic).
+
 ```
 # requirements.txt
 deepagents            # bundles langgraph internally
@@ -204,6 +207,7 @@ langsmith>=0.3.0
 <ex-deepagents-typescript>
 <typescript>
 Minimal package.json dependencies for a Deep Agents project (provider-agnostic).
+
 ```json
 {
   "dependencies": {
@@ -220,6 +224,7 @@ Minimal package.json dependencies for a Deep Agents project (provider-agnostic).
 <ex-with-tools-python>
 <python>
 Adding Tavily search and a vector store to a LangGraph project.
+
 ```
 # requirements.txt
 langchain>=1.0,<2.0
@@ -247,6 +252,7 @@ langchain-text-splitters  # use latest; semver
 <ex-with-tools-typescript>
 <typescript>
 Adding Tavily search and a vector store to a LangGraph project.
+
 ```json
 {
   "dependencies": {
@@ -320,6 +326,7 @@ PINECONE_API_KEY=<your-key>        # for Pinecone
 
 <fix-legacy-version>
 Never start a new project on LangChain 0.3. It is maintenance-only until December 2026.
+
 ```
 # WRONG: legacy, no new features, security patches only
 langchain>=0.3,<0.4
@@ -331,6 +338,7 @@ langchain>=1.0,<2.0
 
 <fix-community-unpinned>
 `langchain-community` can break on minor version bumps — it does not follow semver.
+
 ```
 # WRONG: allows minor-version updates that may be breaking
 langchain-community>=0.4
@@ -343,6 +351,7 @@ Also consider switching to the equivalent dedicated integration package if one e
 
 <fix-community-tool-outdated>
 Community tool packages like `langchain-tavily` and vector store integrations release compatibility fixes alongside LangChain updates. Using an old pinned version can cause import errors or broken tool schemas.
+
 ```
 # RISKY: old pin may be incompatible with LangChain 1.0
 langchain-tavily==0.0.1
@@ -378,6 +387,7 @@ Each entry shows the correct package and import path. If a dedicated package exi
 <fix-core-not-installed>
 <typescript>
 `@langchain/core` is a peer dependency — it must be in your package.json, especially in monorepos.
+
 ```json
 // WRONG: missing @langchain/core (breaks in yarn workspaces / strict hoisting)
 {
@@ -400,6 +410,7 @@ Each entry shows the correct package and import path. If a dedicated package exi
 <fix-python-version>
 <python>
 Python 3.9 and below are not supported by LangChain 1.0.
+
 ```python
 # Verify before installing
 import sys
@@ -411,6 +422,7 @@ assert sys.version_info >= (3, 10), "Python 3.10+ required for LangChain 1.0"
 <fix-node-version>
 <typescript>
 Node.js below 20 is not officially supported.
+
 ```bash
 # Verify before installing
 node --version   # must be v20.x or higher

--- a/config/skills/langchain-fundamentals/SKILL.md
+++ b/config/skills/langchain-fundamentals/SKILL.md
@@ -25,6 +25,7 @@ Build production agents using `create_agent()`, middleware patterns, and the `@t
 
 <ex-basic-agent>
 <python>
+
 ```python
 from langchain.agents import create_agent
 from langchain_core.tools import tool
@@ -51,6 +52,7 @@ print(result["messages"][-1].content)
 ```
 </python>
 <typescript>
+
 ```typescript
 import { createAgent } from "langchain";
 import { tool } from "@langchain/core/tools";
@@ -82,6 +84,7 @@ console.log(result.messages[result.messages.length - 1].content);
 <ex-agent-with-persistence>
 <python>
 Add MemorySaver checkpointer to maintain conversation state across invocations.
+
 ```python
 from langchain.agents import create_agent
 from langgraph.checkpoint.memory import MemorySaver
@@ -102,6 +105,7 @@ result = agent.invoke({"messages": [{"role": "user", "content": "What's my name?
 </python>
 <typescript>
 Add MemorySaver checkpointer to maintain conversation state across invocations.
+
 ```typescript
 import { createAgent } from "langchain";
 import { MemorySaver } from "@langchain/langgraph";
@@ -130,6 +134,7 @@ Tools are functions that agents can call. Use the `@tool` decorator (Python) or 
 
 <ex-basic-tool>
 <python>
+
 ```python
 from langchain_core.tools import tool
 
@@ -145,6 +150,7 @@ def add(a: float, b: float) -> float:
 ```
 </python>
 <typescript>
+
 ```typescript
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
@@ -170,9 +176,11 @@ const add = tool(
 Middleware intercepts the agent loop to add human approval, error handling, logging, and more. A deep understanding of middleware is essential for production agents — use `HumanInTheLoopMiddleware` (Python) / `humanInTheLoopMiddleware` (TypeScript) for approval workflows, and `@wrap_tool_call` (Python) / `createMiddleware` (TypeScript) for custom hooks.
 
 Key imports:
+
 ```python
 from langchain.agents.middleware import HumanInTheLoopMiddleware, wrap_tool_call
 ```
+
 ```typescript
 import { humanInTheLoopMiddleware, createMiddleware } from "langchain";
 ```
@@ -189,6 +197,7 @@ Key patterns:
 Get typed, validated responses from agents using `response_format` or `with_structured_output()`.
 
 <python>
+
 ```python
 from langchain.agents import create_agent
 from pydantic import BaseModel, Field
@@ -212,6 +221,7 @@ response = structured_model.invoke("Extract: John, john@example.com, 555-1234")
 ```
 </python>
 <typescript>
+
 ```typescript
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
@@ -246,6 +256,7 @@ agent = create_agent(model=ChatAnthropic(model="claude-sonnet-4-5", temperature=
 <fix-missing-tool-description>
 <python>
 Clear descriptions help the agent know when to use each tool.
+
 ```python
 # WRONG: Vague or missing description
 @tool
@@ -268,6 +279,7 @@ def search(query: str) -> str:
 </python>
 <typescript>
 Clear descriptions help the agent know when to use each tool.
+
 ```typescript
 // WRONG: Vague description
 const badTool = tool(async ({ input }) => "result", {
@@ -291,6 +303,7 @@ const search = tool(async ({ query }) => webSearch(query), {
 <fix-no-checkpointer>
 <python>
 Add checkpointer and thread_id for conversation memory across invocations.
+
 ```python
 # WRONG: No persistence - agent forgets between calls
 agent = create_agent(model="anthropic:claude-sonnet-4-5", tools=[search])
@@ -314,6 +327,7 @@ agent.invoke({"messages": [{"role": "user", "content": "What's my name?"}]}, con
 </python>
 <typescript>
 Add checkpointer and thread_id for conversation memory across invocations.
+
 ```typescript
 // WRONG: No persistence
 const agent = createAgent({ model: "anthropic:claude-sonnet-4-5", tools: [search] });
@@ -340,6 +354,7 @@ await agent.invoke({ messages: [{ role: "user", content: "What's my name?" }] },
 <fix-infinite-loop>
 <python>
 Set recursion_limit in the invoke config to prevent runaway agent loops.
+
 ```python
 # WRONG: No iteration limit - could loop forever
 result = agent.invoke({"messages": [("user", "Do research")]})
@@ -353,6 +368,7 @@ result = agent.invoke(
 </python>
 <typescript>
 Set recursionLimit in the invoke config to prevent runaway agent loops.
+
 ```typescript
 // WRONG: No iteration limit
 const result = await agent.invoke({ messages: [["user", "Do research"]] });
@@ -369,6 +385,7 @@ const result = await agent.invoke(
 <fix-accessing-result-wrong>
 <python>
 Access the messages array from the result, not result.content directly.
+
 ```python
 # WRONG: Trying to access result.content directly
 result = agent.invoke({"messages": [{"role": "user", "content": "Hello"}]})
@@ -381,6 +398,7 @@ print(result["messages"][-1].content)  # Last message content
 </python>
 <typescript>
 Access the messages array from the result, not result.content directly.
+
 ```typescript
 // WRONG: Trying to access result.content directly
 const result = await agent.invoke({ messages: [{ role: "user", content: "Hello" }] });

--- a/config/skills/langchain-middleware/SKILL.md
+++ b/config/skills/langchain-middleware/SKILL.md
@@ -20,6 +20,7 @@ Middleware patterns for production LangChain agents:
 <ex-basic-hitl-setup>
 <python>
 Set up an agent with HITL middleware that pauses before sending emails for approval.
+
 ```python
 from langchain.agents import create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware
@@ -47,6 +48,7 @@ agent = create_agent(
 </python>
 <typescript>
 Set up an agent with HITL that pauses before sending emails for human approval.
+
 ```typescript
 import { createAgent, humanInTheLoopMiddleware } from "langchain";
 import { MemorySaver } from "@langchain/langgraph";
@@ -79,6 +81,7 @@ const agent = createAgent({
 <ex-running-with-interrupts>
 <python>
 Run the agent, detect an interrupt, then resume execution after human approval.
+
 ```python
 from langgraph.types import Command
 
@@ -102,6 +105,7 @@ result2 = agent.invoke(
 </python>
 <typescript>
 Run the agent, detect an interrupt, then resume execution after human approval.
+
 ```typescript
 import { Command } from "@langchain/langgraph";
 
@@ -129,6 +133,7 @@ const result2 = await agent.invoke(
 <ex-editing-tool-arguments>
 <python>
 Edit the tool arguments before approving when the original values need correction.
+
 ```python
 # Human edits the arguments — edited_action must include name + args
 result2 = agent.invoke(
@@ -151,6 +156,7 @@ result2 = agent.invoke(
 </python>
 <typescript>
 Edit the tool arguments before approving when the original values need correction.
+
 ```typescript
 // Human edits the arguments — editedAction must include name + args
 const result2 = await agent.invoke(
@@ -178,6 +184,7 @@ const result2 = await agent.invoke(
 <ex-rejecting-with-feedback>
 <python>
 Reject a tool call and provide feedback explaining why it was rejected.
+
 ```python
 # Human rejects
 result2 = agent.invoke(
@@ -196,6 +203,7 @@ result2 = agent.invoke(
 <ex-multiple-tools-different-policies>
 <python>
 Configure different HITL policies for each tool based on risk level.
+
 ```python
 agent = create_agent(
     model="gpt-4.1",
@@ -318,6 +326,7 @@ const loggingMiddleware = createMiddleware({
 <fix-missing-checkpointer>
 <python>
 HITL middleware requires a checkpointer to persist state.
+
 ```python
 # WRONG
 agent = create_agent(model="gpt-4.1", tools=[send_email], middleware=[HumanInTheLoopMiddleware({...})])
@@ -332,6 +341,7 @@ agent = create_agent(
 </python>
 <typescript>
 HITL requires a checkpointer to persist state.
+
 ```typescript
 // WRONG: No checkpointer
 const agent = createAgent({
@@ -352,6 +362,7 @@ const agent = createAgent({
 <fix-no-thread-id>
 <python>
 Always provide thread_id when using HITL to track conversation state.
+
 ```python
 # WRONG
 agent.invoke(input)  # No config!
@@ -365,6 +376,7 @@ agent.invoke(input, config={"configurable": {"thread_id": "user-123"}})
 <fix-wrong-resume-syntax>
 <python>
 Use Command class to resume execution after an interrupt.
+
 ```python
 # WRONG
 agent.invoke({"resume": {"decisions": [...]}})
@@ -376,6 +388,7 @@ agent.invoke(Command(resume={"decisions": [{"type": "approve"}]}), config=config
 </python>
 <typescript>
 Use Command class to resume execution after an interrupt.
+
 ```typescript
 // WRONG
 await agent.invoke({ resume: { decisions: [...] } });

--- a/config/skills/langchain-rag/SKILL.md
+++ b/config/skills/langchain-rag/SKILL.md
@@ -36,6 +36,7 @@ Retrieval Augmented Generation (RAG) enhances LLM responses by fetching relevant
 <ex-basic-rag-setup>
 <python>
 End-to-end RAG pipeline: load documents, split into chunks, embed, store, retrieve, and generate a response.
+
 ```python
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from langchain_community.vectorstores import InMemoryVectorStore
@@ -73,6 +74,7 @@ response = model.invoke([
 </python>
 <typescript>
 End-to-end RAG pipeline: load documents, split into chunks, embed, store, retrieve, and generate a response.
+
 ```typescript
 import { ChatOpenAI, OpenAIEmbeddings } from "@langchain/openai";
 import { MemoryVectorStore } from "@langchain/classic/vectorstores/memory";
@@ -117,6 +119,7 @@ const response = await model.invoke([
 <ex-loading-pdf>
 <python>
 Load a PDF file and extract each page as a separate document.
+
 ```python
 from langchain_community.document_loaders import PyPDFLoader
 
@@ -127,6 +130,7 @@ print(f"Loaded {len(docs)} pages")
 </python>
 <typescript>
 Load a PDF file and extract each page as a separate document.
+
 ```typescript
 import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf";
 
@@ -140,6 +144,7 @@ console.log(`Loaded ${docs.length} pages`);
 <ex-loading-web-pages>
 <python>
 Fetch and parse content from a web URL into a document.
+
 ```python
 from langchain_community.document_loaders import WebBaseLoader
 
@@ -149,6 +154,7 @@ docs = loader.load()
 </python>
 <typescript>
 Fetch and parse content from a web URL into a document using Cheerio.
+
 ```typescript
 import { CheerioWebBaseLoader } from "@langchain/community/document_loaders/web/cheerio";
 
@@ -161,6 +167,7 @@ const docs = await loader.load();
 <ex-loading-directory>
 <python>
 Load all text files from a directory using a glob pattern.
+
 ```python
 from langchain_community.document_loaders import DirectoryLoader, TextLoader
 
@@ -182,6 +189,7 @@ docs = loader.load()
 <ex-text-splitting>
 <python>
 Split documents into chunks using RecursiveCharacterTextSplitter with configurable size and overlap.
+
 ```python
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
@@ -203,6 +211,7 @@ splits = splitter.split_documents(docs)
 <ex-chroma-vectorstore>
 <python>
 Create a persistent Chroma vector store and reload it from disk.
+
 ```python
 from langchain_chroma import Chroma
 from langchain_openai import OpenAIEmbeddings
@@ -224,6 +233,7 @@ vectorstore = Chroma(
 </python>
 <typescript>
 Create a Chroma vector store connected to a running Chroma server.
+
 ```typescript
 import { Chroma } from "@langchain/community/vectorstores/chroma";
 import { OpenAIEmbeddings } from "@langchain/openai";
@@ -240,6 +250,7 @@ const vectorstore = await Chroma.fromDocuments(
 <ex-faiss-vectorstore>
 <python>
 Create a FAISS vector store, save it to disk, and reload it.
+
 ```python
 from langchain_community.vectorstores import FAISS
 
@@ -256,6 +267,7 @@ loaded = FAISS.load_local(
 </python>
 <typescript>
 Create a FAISS vector store, save it to disk, and reload it.
+
 ```typescript
 import { FaissStore } from "@langchain/community/vectorstores/faiss";
 
@@ -274,6 +286,7 @@ const loaded = await FaissStore.load("./faiss_index", embeddings);
 <ex-similarity-search>
 <python>
 Perform similarity search and retrieve results with relevance scores.
+
 ```python
 # Basic search
 results = vectorstore.similarity_search(query, k=5)
@@ -286,6 +299,7 @@ for doc, score in results_with_score:
 </python>
 <typescript>
 Perform similarity search and retrieve results with relevance scores.
+
 ```typescript
 // Basic search
 const results = await vectorstore.similaritySearch(query, 5);
@@ -302,6 +316,7 @@ for (const [doc, score] of resultsWithScore) {
 <ex-mmr-search>
 <python>
 Use MMR (Maximal Marginal Relevance) to balance relevance and diversity in search results.
+
 ```python
 # MMR balances relevance and diversity
 retriever = vectorstore.as_retriever(
@@ -315,6 +330,7 @@ retriever = vectorstore.as_retriever(
 <ex-metadata-filtering>
 <python>
 Add metadata to documents and filter search results by metadata properties.
+
 ```python
 # Add metadata when creating documents
 docs = [
@@ -337,6 +353,7 @@ results = vectorstore.similarity_search(
 <ex-rag-with-agent>
 <python>
 Create an agent that uses RAG as a tool for answering questions.
+
 ```python
 from langchain.agents import create_agent
 from langchain.tools import tool
@@ -359,6 +376,7 @@ result = agent.invoke({
 </python>
 <typescript>
 Create an agent that uses RAG as a tool for answering questions.
+
 ```typescript
 import { createAgent } from "langchain";
 import { tool } from "@langchain/core/tools";
@@ -406,6 +424,7 @@ const result = await agent.invoke({
 <fix-chunk-size>
 <python>
 Chunk size 500-1500 is typically good.
+
 ```python
 # WRONG: Too small (loses context) or too large (hits limits)
 splitter = RecursiveCharacterTextSplitter(chunk_size=50)
@@ -417,6 +436,7 @@ splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
 </python>
 <typescript>
 Chunk size 500-1500 is typically good.
+
 ```typescript
 // WRONG: Too small or too large
 const splitter = new RecursiveCharacterTextSplitter({ chunkSize: 50 });
@@ -430,6 +450,7 @@ const splitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000, chunkOver
 <fix-chunk-overlap>
 <python>
 Use overlap (10-20% of chunk size) to maintain context at boundaries.
+
 ```python
 # WRONG: No overlap - context breaks at boundaries
 splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=0)
@@ -443,6 +464,7 @@ splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
 <fix-persist-vectorstore>
 <python>
 Use persistent vector store instead of in-memory to avoid data loss.
+
 ```python
 # WRONG: InMemory - lost on restart
 vectorstore = InMemoryVectorStore.from_documents(docs, embeddings)
@@ -453,6 +475,7 @@ vectorstore = Chroma.from_documents(docs, embeddings, persist_directory="./chrom
 </python>
 <typescript>
 Use persistent vector store instead of in-memory to avoid data loss.
+
 ```typescript
 // WRONG: Memory - lost on restart
 const vectorstore = await MemoryVectorStore.fromDocuments(docs, embeddings);
@@ -466,6 +489,7 @@ const vectorstore = await Chroma.fromDocuments(docs, embeddings, { collectionNam
 <fix-consistent-embeddings>
 <python>
 Use the same embedding model for indexing and querying.
+
 ```python
 # WRONG: Different embeddings for index and query - incompatible!
 vectorstore = Chroma.from_documents(docs, OpenAIEmbeddings(model="text-embedding-3-small"))
@@ -479,6 +503,7 @@ retriever = vectorstore.as_retriever()  # Uses same embeddings
 </python>
 <typescript>
 Use the same embedding model for indexing and querying.
+
 ```typescript
 const embeddings = new OpenAIEmbeddings({ model: "text-embedding-3-small" });
 const vectorstore = await Chroma.fromDocuments(docs, embeddings);
@@ -490,6 +515,7 @@ const retriever = vectorstore.asRetriever();  // Uses same embeddings
 <fix-faiss-deserialization>
 <python>
 Explicitly allow deserialization when loading FAISS indexes.
+
 ```python
 # WRONG: Will raise error
 loaded_store = FAISS.load_local("./faiss_index", embeddings)
@@ -503,6 +529,7 @@ loaded_store = FAISS.load_local("./faiss_index", embeddings, allow_dangerous_des
 <fix-dimension-mismatch>
 <python>
 Ensure embedding dimensions match the vector store index dimensions.
+
 ```python
 # WRONG: Index has 1536 dimensions but using 512-dim embeddings
 pc.create_index(name="idx", dimension=1536, metric="cosine")

--- a/config/skills/langgraph-fundamentals/SKILL.md
+++ b/config/skills/langgraph-fundamentals/SKILL.md
@@ -56,6 +56,7 @@ Follow these 5 steps when building a new graph:
 <ex-state-with-reducer>
 <python>
 Define state schema with reducers for accumulating lists and summing integers.
+
 ```python
 from typing_extensions import TypedDict, Annotated
 import operator
@@ -68,6 +69,7 @@ class State(TypedDict):
 </python>
 <typescript>
 Use StateSchema with ReducedValue for accumulating arrays.
+
 ```typescript
 import { StateSchema, ReducedValue, MessagesValue } from "@langchain/langgraph";
 import { z } from "zod";
@@ -87,6 +89,7 @@ const State = new StateSchema({
 <fix-forgot-reducer-for-list>
 <python>
 Without a reducer, returning a list overwrites previous values.
+
 ```python
 # WRONG: List will be OVERWRITTEN
 class State(TypedDict):
@@ -107,6 +110,7 @@ class State(TypedDict):
 </python>
 <typescript>
 Without ReducedValue, arrays are overwritten not appended.
+
 ```typescript
 // WRONG: Array will be overwritten
 const State = new StateSchema({
@@ -130,6 +134,7 @@ const State = new StateSchema({
 <fix-state-must-return-dict>
 <python>
 Nodes must return partial updates, not mutate and return full state.
+
 ```python
 # WRONG: Returning entire state object
 def my_node(state: State) -> State:
@@ -143,6 +148,7 @@ def my_node(state: State) -> dict:
 </python>
 <typescript>
 Return partial updates only, not the full state object.
+
 ```typescript
 // WRONG: Returning entire state
 const myNode = async (state: typeof State.State) => {
@@ -231,6 +237,7 @@ const nodeWithConfig: GraphNode<typeof State> = (state, config) => {
 <ex-basic-graph>
 <python>
 Simple two-node graph with linear edges.
+
 ```python
 from langgraph.graph import StateGraph, START, END
 from typing_extensions import TypedDict
@@ -261,6 +268,7 @@ print(result["output"])  # "PROCESSED: HELLO"
 </python>
 <typescript>
 Chain nodes with addEdge and compile before invoking.
+
 ```typescript
 import { StateGraph, StateSchema, START, END } from "@langchain/langgraph";
 import { z } from "zod";
@@ -295,6 +303,7 @@ console.log(result.output);  // "PROCESSED: HELLO"
 <ex-conditional-edges>
 <python>
 Route to different nodes based on state with conditional edges.
+
 ```python
 from typing import Literal
 from langgraph.graph import StateGraph, START, END
@@ -327,6 +336,7 @@ graph = (
 </python>
 <typescript>
 addConditionalEdges routes based on function return value.
+
 ```typescript
 import { StateGraph, StateSchema, START, END } from "@langchain/langgraph";
 import { z } from "zod";
@@ -371,6 +381,7 @@ Command combines state updates and routing in a single return value. Fields:
 <ex-command-state-and-routing>
 <python>
 Command lets you update state AND choose next node in one return.
+
 ```python
 from langgraph.types import Command
 from typing import Literal
@@ -400,6 +411,7 @@ graph = (
 </python>
 <typescript>
 Return Command with update and goto to combine state change with routing.
+
 ```typescript
 import { StateGraph, StateSchema, START, END, Command } from "@langchain/langgraph";
 import { z } from "zod";
@@ -452,6 +464,7 @@ Fan-out with `Send`: return `[Send("worker", {...})]` from a conditional edge to
 <ex-orchestrator-worker>
 <python>
 Fan out tasks to parallel workers using the Send API and aggregate results.
+
 ```python
 from langgraph.types import Send
 from typing import Annotated
@@ -487,6 +500,7 @@ result = graph.invoke({"tasks": ["Task A", "Task B", "Task C"]})
 </python>
 <typescript>
 Fan out tasks to parallel workers using the Send API and aggregate results.
+
 ```typescript
 import { Send, StateGraph, StateSchema, ReducedValue, START, END } from "@langchain/langgraph";
 import { z } from "zod";
@@ -526,6 +540,7 @@ const graph = new StateGraph(State)
 <fix-send-accumulator>
 <python>
 Use a reducer to accumulate parallel worker results (otherwise last worker overwrites).
+
 ```python
 # WRONG: No reducer - last worker overwrites
 class State(TypedDict):
@@ -538,6 +553,7 @@ class State(TypedDict):
 </python>
 <typescript>
 Use ReducedValue to accumulate parallel worker results.
+
 ```typescript
 // WRONG: No reducer
 const State = new StateSchema({ results: z.array(z.string()) });
@@ -559,6 +575,7 @@ const State = new StateSchema({
 Call `graph.invoke(input, config)` to run a graph to completion and return the final state.
 
 <python>
+
 ```python
 result = graph.invoke({"input": "hello"})
 # With config (for persistence, tags, etc.)
@@ -566,6 +583,7 @@ result = graph.invoke({"input": "hello"}, {"configurable": {"thread_id": "1"}})
 ```
 </python>
 <typescript>
+
 ```typescript
 const result = await graph.invoke({ input: "hello" });
 // With config
@@ -589,6 +607,7 @@ const result = await graph.invoke({ input: "hello" }, { configurable: { thread_i
 <ex-stream-llm-tokens>
 <python>
 Stream LLM tokens in real-time for chat UI display.
+
 ```python
 for chunk in graph.stream(
     {"messages": [HumanMessage("Hello")]},
@@ -601,6 +620,7 @@ for chunk in graph.stream(
 </python>
 <typescript>
 Stream LLM tokens in real-time for chat UI display.
+
 ```typescript
 for await (const chunk of graph.stream(
   { messages: [new HumanMessage("Hello")] },
@@ -618,6 +638,7 @@ for await (const chunk of graph.stream(
 <ex-stream-custom-data>
 <python>
 Emit custom progress updates from within nodes using the stream writer.
+
 ```python
 from langgraph.config import get_stream_writer
 
@@ -634,6 +655,7 @@ for chunk in graph.stream({"data": "test"}, stream_mode="custom"):
 </python>
 <typescript>
 Emit custom progress updates from within nodes using the stream writer.
+
 ```typescript
 import { getWriter } from "@langchain/langgraph";
 
@@ -672,6 +694,7 @@ Match the error type to the right handler:
 <ex-retry-policy>
 <python>
 Use RetryPolicy for transient errors (network issues, rate limits).
+
 ```python
 from langgraph.types import RetryPolicy
 
@@ -684,6 +707,7 @@ workflow.add_node(
 </python>
 <typescript>
 Use retryPolicy for transient errors.
+
 ```typescript
 workflow.addNode(
   "searchDocumentation",
@@ -699,6 +723,7 @@ workflow.addNode(
 <ex-tool-node-error-handling>
 <python>
 Use ToolNode from langgraph.prebuilt to handle tool execution and errors. When handle_tool_errors=True, errors are returned as ToolMessages so the LLM can recover.
+
 ```python
 from langgraph.prebuilt import ToolNode
 
@@ -709,6 +734,7 @@ workflow.add_node("tools", tool_node)
 </python>
 <typescript>
 Use ToolNode from @langchain/langgraph/prebuilt to handle tool execution and errors. When handleToolErrors is true, errors are returned as ToolMessages so the LLM can recover.
+
 ```typescript
 import { ToolNode } from "@langchain/langgraph/prebuilt";
 
@@ -726,6 +752,7 @@ workflow.addNode("tools", toolNode);
 <fix-compile-before-execution>
 <python>
 Must compile() to get executable graph.
+
 ```python
 # WRONG
 builder.invoke({"input": "test"})  # AttributeError!
@@ -737,6 +764,7 @@ graph.invoke({"input": "test"})
 </python>
 <typescript>
 Must compile() to get executable graph.
+
 ```typescript
 // WRONG
 await builder.invoke({ input: "test" });
@@ -751,6 +779,7 @@ await graph.invoke({ input: "test" });
 <fix-infinite-loop-needs-exit>
 <python>
 Provide conditional path to END to avoid infinite loops.
+
 ```python
 # WRONG: Loops forever
 builder.add_edge("node_a", "node_b")
@@ -764,6 +793,7 @@ builder.add_conditional_edges("node_a", should_continue)
 </python>
 <typescript>
 Use conditional edges with END return to break loops.
+
 ```typescript
 // WRONG: Loops forever
 builder.addEdge("node_a", "node_b").addEdge("node_b", "node_a");
@@ -776,6 +806,7 @@ builder.addConditionalEdges("node_a", (state) => state.count > 10 ? END : "node_
 
 <fix-common-mistakes>
 Other common mistakes:
+
 ```python
 # Router must return names of nodes that exist in the graph
 builder.add_node("my_node", func)  # Add node BEFORE referencing in edges
@@ -792,6 +823,7 @@ builder.add_edge("node_a", "entry")  # Use a named entry node instead
 # Reducer expects matching types
 return {"items": ["item"]}  # List for list reducer, not a string
 ```
+
 ```typescript
 // Always await graph.invoke() - it returns a Promise
 const result = await graph.invoke({ input: "test" });

--- a/config/skills/langgraph-human-in-the-loop/SKILL.md
+++ b/config/skills/langgraph-human-in-the-loop/SKILL.md
@@ -33,6 +33,7 @@ Three things are required for interrupts to work:
 <ex-basic-interrupt-resume>
 <python>
 Pause execution for human review and resume with Command.
+
 ```python
 from langgraph.types import interrupt, Command
 from langgraph.checkpoint.memory import InMemorySaver
@@ -71,6 +72,7 @@ print(result["approved"])  # True
 </python>
 <typescript>
 Pause execution for human review and resume with Command.
+
 ```typescript
 import { interrupt, Command, MemorySaver, StateGraph, StateSchema, START, END } from "@langchain/langgraph";
 import { z } from "zod";
@@ -116,6 +118,7 @@ A common pattern: interrupt to show a draft, then route based on the human's dec
 <ex-approval-workflow>
 <python>
 Interrupt for human review, then route to send or end based on the decision.
+
 ```python
 from langgraph.types import interrupt, Command
 from langgraph.graph import StateGraph, START, END
@@ -152,6 +155,7 @@ def human_review(state: EmailAgentState) -> Command[Literal["send_reply", "__end
 </python>
 <typescript>
 Interrupt for human review, then route to send or end based on the decision.
+
 ```typescript
 import { interrupt, Command, END, GraphNode } from "@langchain/langgraph";
 
@@ -189,6 +193,7 @@ Use `interrupt()` in a loop to validate human input and re-prompt if invalid.
 <ex-validation-loop>
 <python>
 Validate human input in a loop, re-prompting until valid.
+
 ```python
 from langgraph.types import interrupt
 
@@ -209,6 +214,7 @@ def get_age_node(state):
 ```
 
 Each `Command(resume=...)` call provides the next answer. If invalid, the loop re-interrupts with a clearer message.
+
 ```python
 config = {"configurable": {"thread_id": "form-1"}}
 first = graph.invoke({"age": None}, config)
@@ -223,6 +229,7 @@ print(final["age"])  # 30
 </python>
 <typescript>
 Validate human input in a loop, re-prompting until valid.
+
 ```typescript
 import { interrupt } from "@langchain/langgraph";
 
@@ -254,6 +261,7 @@ When parallel branches each call `interrupt()`, resume all of them in a single i
 <ex-multiple-interrupts>
 <python>
 Resume multiple parallel interrupts by mapping interrupt IDs to values.
+
 ```python
 from typing import Annotated, TypedDict
 import operator
@@ -300,6 +308,7 @@ result = graph.invoke(Command(resume=resume_map), config)
 </python>
 <typescript>
 Resume multiple parallel interrupts by mapping interrupt IDs to values.
+
 ```typescript
 import { Command, END, MemorySaver, START, StateGraph, interrupt, isInterrupted, INTERRUPT, Annotation } from "@langchain/langgraph";
 
@@ -373,6 +382,7 @@ When the graph resumes, the node restarts from the **beginning** — ALL code be
 <ex-idempotent-patterns>
 <python>
 Idempotent operations before interrupt vs non-idempotent (wrong).
+
 ```python
 # GOOD: Upsert is idempotent — safe before interrupt
 def node_a(state: State):
@@ -399,6 +409,7 @@ def node_a(state: State):
 </python>
 <typescript>
 Idempotent operations before interrupt vs non-idempotent (wrong).
+
 ```typescript
 // GOOD: Upsert is idempotent — safe before interrupt
 const nodeA = async (state: typeof State.State) => {
@@ -436,6 +447,7 @@ const nodeA = async (state: typeof State.State) => {
 When a subgraph contains an `interrupt()`, resuming re-executes BOTH the parent node (that invoked the subgraph) AND the subgraph node (that called `interrupt()`):
 
 <python>
+
 ```python
 def node_in_parent_graph(state: State):
     some_code()  # <-- Re-executes on resume
@@ -449,6 +461,7 @@ def node_in_subgraph(state: State):
 ```
 </python>
 <typescript>
+
 ```typescript
 async function nodeInParentGraph(state: State) {
   someCode();  // <-- Re-executes on resume
@@ -478,6 +491,7 @@ async function nodeInSubgraph(state: State) {
 <fix-checkpointer-required-for-interrupts>
 <python>
 Checkpointer required for interrupt functionality.
+
 ```python
 # WRONG
 graph = builder.compile()
@@ -488,6 +502,7 @@ graph = builder.compile(checkpointer=InMemorySaver())
 </python>
 <typescript>
 Checkpointer required for interrupt functionality.
+
 ```typescript
 // WRONG
 const graph = builder.compile();
@@ -501,6 +516,7 @@ const graph = builder.compile({ checkpointer: new MemorySaver() });
 <fix-resume-with-command>
 <python>
 Use Command to resume from an interrupt (regular dict restarts graph).
+
 ```python
 # WRONG
 graph.invoke({"resume_data": "approve"}, config)
@@ -511,6 +527,7 @@ graph.invoke(Command(resume="approve"), config)
 </python>
 <typescript>
 Use Command to resume from an interrupt (regular object restarts graph).
+
 ```typescript
 // WRONG
 await graph.invoke({ resumeData: "approve" }, config);

--- a/config/skills/langgraph-persistence/SKILL.md
+++ b/config/skills/langgraph-persistence/SKILL.md
@@ -32,6 +32,7 @@ LangGraph's persistence layer enables durable execution by checkpointing graph s
 <ex-basic-persistence>
 <python>
 Set up a basic graph with in-memory checkpointing and thread-based state persistence.
+
 ```python
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.graph import StateGraph, START, END
@@ -66,6 +67,7 @@ print(len(result2["messages"]))  # 4 (previous + new)
 </python>
 <typescript>
 Set up a basic graph with in-memory checkpointing and thread-based state persistence.
+
 ```typescript
 import { MemorySaver, StateGraph, StateSchema, MessagesValue, START, END } from "@langchain/langgraph";
 import { HumanMessage } from "@langchain/core/messages";
@@ -99,6 +101,7 @@ console.log(result2.messages.length);  // 4 (previous + new)
 <ex-production-postgres>
 <python>
 Configure PostgreSQL-backed checkpointing for production deployments.
+
 ```python
 from langgraph.checkpoint.postgres import PostgresSaver
 
@@ -111,6 +114,7 @@ with PostgresSaver.from_conn_string(
 </python>
 <typescript>
 Configure PostgreSQL-backed checkpointing for production deployments.
+
 ```typescript
 import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres";
 
@@ -131,6 +135,7 @@ const graph = builder.compile({ checkpointer });
 <ex-separate-threads>
 <python>
 Demonstrate isolated state between different thread IDs.
+
 ```python
 # Different threads maintain separate state
 alice_config = {"configurable": {"thread_id": "user-alice"}}
@@ -144,6 +149,7 @@ graph.invoke({"messages": ["Hi from Bob"]}, bob_config)
 </python>
 <typescript>
 Demonstrate isolated state between different thread IDs.
+
 ```typescript
 // Different threads maintain separate state
 const aliceConfig = { configurable: { thread_id: "user-alice" } };
@@ -164,6 +170,7 @@ await graph.invoke({ messages: [new HumanMessage("Hi from Bob")] }, bobConfig);
 <ex-resume-from-checkpoint>
 <python>
 Time travel: browse checkpoint history and replay or fork from a past state.
+
 ```python
 config = {"configurable": {"thread_id": "session-1"}}
 
@@ -183,6 +190,7 @@ result = graph.invoke(None, fork_config)
 </python>
 <typescript>
 Time travel: browse checkpoint history and replay or fork from a past state.
+
 ```typescript
 const config = { configurable: { thread_id: "session-1" } };
 
@@ -208,6 +216,7 @@ const forked = await graph.invoke(null, forkConfig);
 <ex-update-state>
 <python>
 Manually update graph state before resuming execution.
+
 ```python
 config = {"configurable": {"thread_id": "session-1"}}
 
@@ -220,6 +229,7 @@ result = graph.invoke(None, config)
 </python>
 <typescript>
 Manually update graph state before resuming execution.
+
 ```typescript
 const config = { configurable: { thread_id: "session-1" } };
 
@@ -269,6 +279,7 @@ When compiling a subgraph, the `checkpointer` parameter controls persistence beh
 <ex-subgraph-checkpointer-modes>
 <python>
 Choose the right checkpointer mode for your subgraph.
+
 ```python
 # No interrupts needed — opt out of checkpointing
 subgraph = subgraph_builder.compile(checkpointer=False)
@@ -282,6 +293,7 @@ subgraph = subgraph_builder.compile(checkpointer=True)
 </python>
 <typescript>
 Choose the right checkpointer mode for your subgraph.
+
 ```typescript
 // No interrupts needed — opt out of checkpointing
 const subgraph = subgraphBuilder.compile({ checkpointer: false });
@@ -302,6 +314,7 @@ const subgraph = subgraphBuilder.compile({ checkpointer: true });
 When multiple **different** stateful subgraphs run in parallel, wrap each in its own `StateGraph` with a unique node name for stable namespace isolation:
 
 <python>
+
 ```python
 from langgraph.graph import MessagesState, StateGraph
 
@@ -326,6 +339,7 @@ veggie_agent = create_sub_agent(
 ```
 </python>
 <typescript>
+
 ```typescript
 import { StateGraph, StateSchema, MessagesValue, START } from "@langchain/langgraph";
 
@@ -357,6 +371,7 @@ Note: Subgraphs added as nodes (via `add_node`) already get name-based namespace
 <ex-long-term-memory-store>
 <python>
 Use a Store for cross-thread memory to share user preferences across conversations.
+
 ```python
 from langgraph.store.memory import InMemoryStore
 
@@ -382,6 +397,7 @@ graph.invoke({"user_id": "alice"}, {"configurable": {"thread_id": "thread-2"}}) 
 </python>
 <typescript>
 Use a Store for cross-thread memory to share user preferences across conversations.
+
 ```typescript
 import { MemoryStore } from "@langchain/langgraph";
 
@@ -409,6 +425,7 @@ await graph.invoke({ userId: "alice" }, { configurable: { thread_id: "thread-2" 
 <ex-store-operations>
 <python>
 Basic store operations: put, get, search, and delete.
+
 ```python
 from langgraph.store.memory import InMemoryStore
 
@@ -429,6 +446,7 @@ store.delete(("user-123", "facts"), "location")  # Delete
 <fix-thread-id-required>
 <python>
 Always provide thread_id in config to enable state persistence.
+
 ```python
 # WRONG: No thread_id - state NOT persisted!
 graph.invoke({"messages": ["Hello"]})
@@ -442,6 +460,7 @@ graph.invoke({"messages": ["What did I say?"]}, config)  # Remembers!
 </python>
 <typescript>
 Always provide thread_id in config to enable state persistence.
+
 ```typescript
 // WRONG: No thread_id - state NOT persisted!
 await graph.invoke({ messages: [new HumanMessage("Hello")] });
@@ -459,6 +478,7 @@ await graph.invoke({ messages: [new HumanMessage("What did I say?")] }, config);
 <fix-inmemory-not-for-production>
 <python>
 Use PostgresSaver instead of InMemorySaver for production persistence.
+
 ```python
 # WRONG: Data lost on process restart
 checkpointer = InMemorySaver()  # In-memory only!
@@ -472,6 +492,7 @@ with PostgresSaver.from_conn_string("postgresql://...") as checkpointer:
 </python>
 <typescript>
 Use PostgresSaver instead of MemorySaver for production persistence.
+
 ```typescript
 // WRONG: Data lost on process restart
 const checkpointer = new MemorySaver();  // In-memory only!
@@ -488,6 +509,7 @@ await checkpointer.setup(); // only needed on first use to create tables
 <fix-update-state-with-reducers>
 <python>
 Use Overwrite to replace state values instead of passing through reducers.
+
 ```python
 from langgraph.types import Overwrite
 
@@ -503,6 +525,7 @@ graph.update_state(config, {"items": Overwrite(["C"])})  # Result: ["C"] - Repla
 </python>
 <typescript>
 Use Overwrite to replace state values instead of passing through reducers.
+
 ```typescript
 import { Overwrite } from "@langchain/langgraph";
 
@@ -521,6 +544,7 @@ await graph.updateState(config, { items: new Overwrite(["C"]) });  // Result: ["
 <fix-store-injection>
 <python>
 Access store via the Runtime object in graph nodes.
+
 ```python
 # WRONG: Store not available in node
 def my_node(state):
@@ -535,6 +559,7 @@ def my_node(state, runtime: Runtime):
 </python>
 <typescript>
 Access store via runtime parameter in graph nodes.
+
 ```typescript
 // WRONG: Store not available in node
 const myNode = async (state) => {


### PR DESCRIPTION
## Summary
- Add blank lines before fenced code blocks across skill documentation for consistent Markdown rendering.
- Apply the same spacing cleanup to README and AGENTS examples.

## Test plan
- Verified all opening code fences have a preceding blank line.
- Ran `git diff --check`.
- Checked Markdown lint diagnostics in Cursor.


Made with [Cursor](https://cursor.com)