### PR TITLE
fix(langgraph-persistence): use env var for DSN and move setup() out of runtime path

### DIFF
--- a/config/skills/langgraph-persistence/SKILL.md
+++ b/config/skills/langgraph-persistence/SKILL.md
@@ -100,12 +100,13 @@ console.log(result2.messages.length);  // 4 (previous + new)
 <python>
 Configure PostgreSQL-backed checkpointing for production deployments.
 ```python
+import os
 from langgraph.checkpoint.postgres import PostgresSaver
 
-with PostgresSaver.from_conn_string(
-    "postgresql://user:pass@localhost/db"
-) as checkpointer:
-    checkpointer.setup()  # only needed on first use to create tables
+# Run once during deployment (not at application startup):
+#   PostgresSaver.from_conn_string(os.environ["DATABASE_URL"]).setup()
+
+with PostgresSaver.from_conn_string(os.environ["DATABASE_URL"]) as checkpointer:
     graph = builder.compile(checkpointer=checkpointer)
 ```
 </python>
@@ -114,11 +115,10 @@ Configure PostgreSQL-backed checkpointing for production deployments.
 ```typescript
 import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres";
 
-const checkpointer = PostgresSaver.fromConnString(
-  "postgresql://user:pass@localhost/db"
-);
-await checkpointer.setup(); // only needed on first use to create tables
+// Run once during deployment (not at application startup):
+//   await PostgresSaver.fromConnString(process.env.DATABASE_URL!).setup();
 
+const checkpointer = PostgresSaver.fromConnString(process.env.DATABASE_URL!);
 const graph = builder.compile({ checkpointer });
 ```
 </typescript>


### PR DESCRIPTION
## Summary
- Replace hardcoded `postgresql://user:pass@localhost/db` connection string with `os.environ["DATABASE_URL"]` / `process.env.DATABASE_URL`
- Move `checkpointer.setup()` call out of the runtime path — it now appears as a comment instructing users to run it once during deployment, not on every app startup

## Test plan
- [ ] Verify the Python and TypeScript examples in `config/skills/langgraph-persistence/SKILL.md` render correctly
- [ ] Confirm no other skill files reference hardcoded Postgres DSNs

🤖 Generated with [Claude Code](https://claude.com/claude-code)