### PR TITLE
chore: write swarm tables to temp path

### DIFF
--- a/config/skills/swarm/scripts/table.ts
+++ b/config/skills/swarm/scripts/table.ts
@@ -37,7 +37,7 @@ function sanitizeSessionId(id: string): string {
  */
 function getTableDir(): string {
   const id = typeof __sessionId__ !== "undefined" ? __sessionId__ : "default";
-  return `.swarm/${sanitizeSessionId(id)}`;
+  return `/tmp/.swarm/${sanitizeSessionId(id)}`;
 }
 
 /**

--- a/tests/swarm/table.test.ts
+++ b/tests/swarm/table.test.ts
@@ -76,11 +76,11 @@ describe("generateId", () => {
 
 describe("tablePath", () => {
   it("zero-pads the sequence number", () => {
-    expect(tablePath(0, "t_abc123")).toBe(".swarm/default/000-t_abc123.jsonl");
-    expect(tablePath(3, "t_abc123")).toBe(".swarm/default/003-t_abc123.jsonl");
-    expect(tablePath(42, "t_abc123")).toBe(".swarm/default/042-t_abc123.jsonl");
+    expect(tablePath(0, "t_abc123")).toBe("/tmp/.swarm/default/000-t_abc123.jsonl");
+    expect(tablePath(3, "t_abc123")).toBe("/tmp/.swarm/default/003-t_abc123.jsonl");
+    expect(tablePath(42, "t_abc123")).toBe("/tmp/.swarm/default/042-t_abc123.jsonl");
     expect(tablePath(999, "t_abc123")).toBe(
-      ".swarm/default/999-t_abc123.jsonl",
+      "/tmp/.swarm/default/999-t_abc123.jsonl",
     );
   });
 });
@@ -458,6 +458,6 @@ describe("sequence numbering", () => {
     const handle = await createTable({ tasks: [{ id: "r3" }] });
     const path = [...files.keys()].find((k) => k.includes(handle.id));
     expect(path).toBeDefined();
-    expect(path).toMatch(/^\.swarm\/default\/00[2-9]/);
+    expect(path).toMatch(/^\/tmp\/\.swarm\/default\/00[2-9]/);
   });
 });


### PR DESCRIPTION
### Summary

This PR just updates the table creation path to always be in the tmp directory for swarm tables.