### PR TITLE
docs: update managed deep agents skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Then run your coding agent from the directory where you installed (for local ins
 - **deep-agents-core** - Agent architecture, harness setup, and SKILL.md format
 - **deep-agents-memory** - Memory, persistence, filesystem middleware
 - **deep-agents-orchestration** - Subagents, task planning, human-in-the-loop
-- **managed-deep-agents** - Managed Deep Agents private-preview REST API (`/v1/deepagents`): create agents, register MCP servers, create threads, stream runs
+- **managed-deep-agents** - Managed Deep Agents: deploy with the CLI, use the SDKs, stream runs, connect MCP tools, and build React `useStream` UIs
 
 ### LangChain
 - **langchain-fundamentals** - Agents with create_agent, tools, structured output, middleware basics

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -25,7 +25,7 @@ This project uses skills that contain up-to-date patterns and working reference 
 - **deep-agents-core** - Invoke for Deep Agents harness architecture
 - **deep-agents-memory** - Invoke for long-term memory with StoreBackend
 - **deep-agents-orchestration** - Invoke for multi-agent coordination
-- **managed-deep-agents** - Invoke for the Managed Deep Agents private-preview REST API (`/v1/deepagents`): create agents, register MCP servers, create threads, stream runs
+- **managed-deep-agents** - Invoke for Managed Deep Agents: deploy with the CLI, use the SDKs, stream runs, connect MCP tools, and build React `useStream` UIs
 
 ## Environment Setup
 

--- a/config/skills/managed-deep-agents/SKILL.md
+++ b/config/skills/managed-deep-agents/SKILL.md
@@ -1,193 +1,414 @@
 ---
 name: managed-deep-agents
-description: "INVOKE THIS SKILL when creating, running, or operating a Managed Deep Agent against the LangSmith /v1/deepagents private-preview REST API. Covers the agent → MCP server → thread → streamed run flow, tool/interrupt configuration, and the agent file tree (AGENTS.md, skills/, subagents/, tools.json)."
+description: "INVOKE THIS SKILL when creating, deploying, running, or operating Managed Deep Agents in LangSmith. Covers deepagents-cli, the Python and TypeScript SDKs, React useStream, REST fallbacks, MCP tools, interrupts, backends, and the managed agent file tree."
 ---
 
 # Managed Deep Agents
 
 ## Overview
 
-Managed Deep Agents is an API-first hosted runtime for creating, running, and operating Deep Agents in LangSmith. It packages the operational layer around the open-source Deep Agents harness — versioned agent repo in the Context Hub, durable threads, streamed runs, managed file tree, MCP credential storage — so you don't have to stand up your own agent server.
+Managed Deep Agents is a hosted runtime for creating, running, and operating Deep Agents in LangSmith. It packages the operational layer around the open-source Deep Agents harness: a versioned Context Hub agent repo, durable threads, streamed runs, MCP credential storage, managed files, and optional LangSmith sandboxes.
 
-For self-hosted deployments or full Agent Server APIs, use a standard LangSmith Deployment via [[langgraph-cli]] instead.
+Use the Managed Deep Agents path when the user wants LangSmith to host and operate the agent. For self-hosted deployments, custom application routes, or the full Agent Server API surface, use a standard LangSmith Deployment via [[langgraph-cli]] instead.
 
 ## When to use
 
 Use this skill when the user wants to:
-- Create or update a Managed Deep Agent (`POST` / `PATCH /v1/deepagents/agents`)
-- Run an agent on a durable thread and stream the result
-- Register or rotate MCP server credentials for an agent's tools
-- Configure per-tool human-in-the-loop interrupts on a managed agent
-- Decide between Managed Deep Agents and a self-hosted LangSmith Deployment
+
+- Deploy a Managed Deep Agent from local project files.
+- Create or update a Managed Deep Agent from Python, TypeScript, or REST.
+- Run an agent on a durable thread and stream output.
+- Build a React chat UI with `@langchain/react` `useStream`.
+- Register MCP servers, list MCP tools, or configure tool interrupts.
+- Choose between Managed Deep Agents and a self-hosted LangSmith Deployment.
 
 ## Prerequisites
 
-- A LangSmith API key for that workspace
-- The HTTP client of your choice (`httpx` in Python, built-in `fetch` in JS/Node 18+)
+- Managed Deep Agents preview access in the target LangSmith workspace.
+- A LangSmith API key for that workspace.
+- One of the supported clients:
+
+```bash
+uv tool install "deepagents-cli>=0.2.2"
+pip install managed-deepagents
+npm install @langchain/managed-deepagents @langchain/react
+```
+
+Set the API key in the shell or server environment:
 
 ```bash
 export LANGSMITH_API_KEY="<LANGSMITH_API_KEY>"
+```
+
+The SDKs default to `https://api.smith.langchain.com/v1/deepagents`. To use a different compatible endpoint, set `LANGSMITH_ENDPOINT` or pass `api_url` / `apiUrl` in the client.
+
+For direct REST examples, set:
+
+```bash
 export DEEPAGENTS_BASE_URL="https://api.smith.langchain.com/v1/deepagents"
 ```
 
-All requests authenticate via the `X-Api-Key` header:
+All REST requests authenticate with:
 
-```
+```text
 X-Api-Key: <LANGSMITH_API_KEY>
 ```
 
-## End-to-end flow
+Never expose a long-lived LangSmith API key in browser code. For browser apps, route requests through your own backend or provide a custom `fetch` implementation that proxies requests server-side.
 
-```
-1. Register MCP server(s) →  POST /v1/deepagents/mcp-servers
-2. Create the agent       →  POST /v1/deepagents/agents
-3. Create a thread        →  POST /v1/deepagents/threads
-4. Stream a run           →  POST /v1/deepagents/threads/{thread_id}/runs/stream
-5. Inspect in LangSmith   →  Traces UI
-```
+## Choose an interface
 
-Each step is independent — register MCP servers once per workspace, then point any number of agents at them.
+| Interface | Use for |
+| --- | --- |
+| `deepagents-cli>=0.2.2` | Normal project-file workflow: scaffold, edit files, deploy, manage MCP servers. |
+| Python SDK `managed-deepagents` | Server-side Python automation, tests, scripts, services, and streaming. |
+| TypeScript SDK `@langchain/managed-deepagents` | Server-side TypeScript automation and LangGraph-compatible streaming. |
+| React `useStream` | Chat UIs that should let LangGraph own thread/run/projection state. |
+| REST `/v1/deepagents` | Low-level fallback when a client does not expose a field yet. |
+
+Prefer the CLI for local agent projects. Prefer the SDKs for application code. Use REST only when you need exact request control.
 
 ## Resource groups
 
 | Group | Purpose |
-|-------|---------|
-| **Agents** (`/agents`) | Create, list, get, update (`PATCH`), and delete Managed Deep Agents. |
-| **Threads** (`/threads`) | Create, search, count, and inspect durable thread state. |
-| **Runs** (`/threads/{thread_id}/runs/stream`) | Start and stream runs on a thread (server-sent events). |
-| **MCP servers** (`/mcp-servers`) | Register, list, rotate credentials, and delete MCP servers referenced by agent tools. |
+| --- | --- |
+| Agents | Create, list, get, update, clone, delete, and health-check Managed Deep Agents. |
+| Threads | Create, list, search, count, inspect, update, and delete durable thread state. |
+| Runs | Start and stream runs on a thread. |
+| MCP servers | Register, list, update, delete, and connect MCP servers. |
+| MCP tools | List tools exposed by a registered MCP server for `tools.json`. |
+| Auth sessions | Start and inspect OAuth authorization sessions. |
 
-## Agent file tree
+## Project file tree
 
-Managed Deep Agents keeps the familiar Deep Agents project shape. Keep these in your source repo (so updates are reviewable) and submit them in `POST` / `PATCH /agents` payloads. The platform stores them as a versioned agent repo in the Context Hub, returns a `revision` on each update, and serves the tree to the agent on every run.
+The CLI uses a local project directory and deploys it into the managed Context Hub agent repo.
+
+```text
+my-agent/
+  agent.json
+  AGENTS.md
+  tools.json
+  skills/<name>/SKILL.md
+  subagents/<name>/agent.json
+  subagents/<name>/AGENTS.md
+  subagents/<name>/tools.json
+```
 
 | File / directory | Purpose |
-|------------------|---------|
-| `AGENTS.md` | Agent instructions. |
-| `skills/` | Skill definitions the agent can use. |
-| `subagents/` | Subagent definitions for delegated work. |
-| `tools.json` | Tool configuration (`tools` + `interrupt_config`). |
+| --- | --- |
+| `agent.json` | Agent name, description, model, backend, permissions, and optional target `agent_id`. |
+| `AGENTS.md` | Main agent instructions. |
+| `tools.json` | MCP-backed tools plus `interrupt_config`. |
+| `skills/` | Reusable instructions and files the agent can load. |
+| `subagents/` | Delegated worker definitions and optional subagent-scoped tools. |
 
-At runtime, the agent can read and write files — including a `/memories/` directory for durable cross-run state.
+At runtime, the agent can read and write managed files, including memory files created by the Deep Agents harness.
 
-## `tools` configuration
+## Backends
 
-Tools are configured with a `tools` array and an `interrupt_config` map. The same shape is used in `tools.json` and inline in agent create/update payloads:
+New projects should use the canonical backend names from `deepagents-cli>=0.2.2`.
+
+Use `state` when the agent does not need sandbox-specific backend behavior:
+
+```json
+{
+  "backend": {
+    "type": "state"
+  }
+}
+```
+
+Use `sandbox` when the agent needs a LangSmith sandbox for code execution, filesystem work, or long-running tasks:
+
+```json
+{
+  "backend": {
+    "type": "sandbox",
+    "sandbox_config": {
+      "scope": "thread",
+      "policy_ids": ["policy-id"],
+      "idle_ttl_seconds": 900,
+      "delete_after_stop_seconds": 300
+    }
+  }
+}
+```
+
+`sandbox_config.scope` must be `thread` or `agent`.
+
+## CLI workflow
+
+Use the CLI for most deploy workflows.
+
+```bash
+deepagents init research-assistant
+cd research-assistant
+```
+
+Edit `agent.json`:
+
+```json
+{
+  "name": "research-assistant",
+  "description": "Research assistant that can search the web and summarize sources.",
+  "model": "openai:gpt-5.5",
+  "backend": {
+    "type": "state"
+  }
+}
+```
+
+Edit `AGENTS.md` with the main instructions, then deploy:
+
+```bash
+deepagents deploy
+```
+
+Useful CLI commands:
+
+| Command | Use |
+| --- | --- |
+| `deepagents --version` | Confirm `deepagents-cli>=0.2.2`. |
+| `deepagents deploy --dry-run` | Print the agent payload and managed file tree without deploying. |
+| `deepagents agents list` | List Managed Deep Agents in the workspace. |
+| `deepagents agents get <agent_id> --include-files` | Inspect an agent and its managed files. |
+| `deepagents mcp-servers add --url URL --name NAME` | Register a static-header MCP server. |
+| `deepagents mcp-servers add --url URL --auth-type oauth --connect` | Register and connect an OAuth MCP server. |
+| `deepagents mcp-servers tools <id|name|url>` | List tools and print a paste-ready `tools.json` snippet. |
+| `deepagents mcp-servers connect <id|name|url>` | Complete OAuth for a registered OAuth MCP server. |
+
+For shared repositories, put the target `agent_id` in `agent.json`; the CLI asks for confirmation before updating that remote agent. Use `--yes` only when the target is intentional.
+
+## MCP tools
+
+Tools are configured with a `tools` array and an `interrupt_config` map. The same shape is used in `tools.json` and inline SDK/REST create or update payloads.
 
 ```json
 {
   "tools": [
     {
-      "name": "tavily_search",
-      "mcp_server_url": "https://mcp.tavily.com/mcp/",
-      "mcp_server_name": "tavily",
-      "display_name": "tavily_search"
+      "name": "read_url_content",
+      "mcp_server_url": "https://example.com/mcp",
+      "mcp_server_name": "my-tools",
+      "display_name": "read_url_content"
     }
   ],
   "interrupt_config": {
-    "https://mcp.tavily.com/mcp/::tavily-search::tavily": false
+    "https://example.com/mcp::read_url_content": false
   }
 }
 ```
 
-- Each `tools[].mcp_server_url` must match an MCP server already registered for the workspace; credentials are attached automatically at invocation time.
-- `tools[].name` is the tool name **exposed by the MCP server itself**, not the workspace's MCP-server display name. Confirm the name with `tools/list` against the server (e.g. Tavily's MCP exposes `tavily_search` with an underscore, even if you registered the server under any other name). The model will not see the tool if this name is wrong.
-- `interrupt_config` keys use the form `{mcp_server_url}::{tool_name}` (two colons, trailing slashes on the URL stripped before matching). Additional `::`-separated parts (e.g. the MCP server display name) are accepted but ignored when matching.
-- Set the value to `true` to require human approval before the tool runs, `false` to allow it without interrupt.
+- `tools[].mcp_server_url` must match a registered workspace MCP server URL.
+- `tools[].name` is the tool name exposed by the MCP server, not the workspace MCP-server display name.
+- Use `deepagents mcp-servers tools <server>` or the SDK tool-listing methods to confirm exact tool names.
+- `interrupt_config` keys use `{mcp_server_url}::{tool_name}`. Additional `::` parts are accepted for compatibility, but do not rely on them for new configs.
+- Set the interrupt value to `true` to require human approval before the tool runs.
 
-## Step 1 — Register an MCP server
-
-Tools that need credentials (custom MCP servers, private endpoints, any bearer-authenticated API) are registered once per workspace via `POST /v1/deepagents/mcp-servers`. The platform stores the URL and credential headers (encrypted at rest) and re-attaches them on every invocation whose `tools[].mcp_server_url` matches.
+Python SDK tool listing:
 
 ```python
-import os, httpx
+from managed_deepagents import Client
+
+with Client() as client:
+    tools = client.mcp_servers.list_tools(
+        url="https://example.com/mcp",
+        force_refresh=True,
+    )
+    print(tools["tools"])
+```
+
+TypeScript SDK tool listing:
+
+```ts
+import { Client } from "@langchain/managed-deepagents";
+
+const client = new Client({ apiKey: process.env.LANGSMITH_API_KEY });
+const tools = await client.mcpServers.listTools({
+  url: "https://example.com/mcp",
+  forceRefresh: true,
+});
+console.log(tools.tools);
+```
+
+## Python SDK workflow
+
+Use the Python SDK for server-side automation and streaming.
+
+```python
+from managed_deepagents import Client
+
+with Client() as client:
+    agent = client.agents.create(
+        name="research-assistant",
+        description="Research assistant that can search the web and summarize sources.",
+        model="openai:gpt-5.5",
+        backend={"type": "state"},
+        instructions=(
+            "You are a careful research assistant. Search for sources, "
+            "keep notes, and return concise answers with citations."
+        ),
+    )
+
+    thread = client.threads.create(
+        agent_id=agent["id"],
+        options={
+            "test_run": False,
+            "skip_memory_write_protection": False,
+        },
+    )
+
+    for event in client.threads.stream(
+        thread["id"],
+        agent_id=agent["id"],
+        messages=[
+            {
+                "role": "user",
+                "content": "Research recent approaches to agent memory and summarize the main tradeoffs.",
+            }
+        ],
+        stream_mode=["values", "updates", "messages-tuple"],
+        stream_subgraphs=True,
+        user_timezone="America/Los_Angeles",
+    ):
+        print(event.event, event.data)
+```
+
+Async Python clients are available as `AsyncClient` with matching resource names.
+
+## TypeScript SDK workflow
+
+Use the TypeScript SDK for server-side automation and LangGraph-compatible streaming.
+
+```ts
+import { Client } from "@langchain/managed-deepagents";
+
+const client = new Client({
+  apiKey: process.env.LANGSMITH_API_KEY,
+});
+
+const agent = await client.agents.create({
+  name: "research-assistant",
+  description: "Research assistant that can search the web and summarize sources.",
+  model: "openai:gpt-5.5",
+  backend: { type: "state" },
+  instructions:
+    "You are a careful research assistant. Search for sources, keep notes, and return concise answers with citations.",
+});
+
+const thread = await client.threads.create({
+  agent_id: agent.id,
+  options: {
+    test_run: false,
+    skip_memory_write_protection: false,
+  },
+});
+
+const langGraphClient = client.getLangGraphClient({ agentId: agent.id });
+const stream = langGraphClient.runs.stream(thread.id, agent.id, {
+  input: {
+    messages: [
+      {
+        role: "user",
+        content:
+          "Research recent approaches to agent memory and summarize the main tradeoffs.",
+      },
+    ],
+  },
+  streamMode: ["values", "updates", "messages-tuple"],
+  streamSubgraphs: true,
+});
+
+for await (const event of stream) {
+  console.log(event.event, event.data);
+}
+```
+
+The adapter translates LangGraph SDK request fields into Managed Deep Agents routes, headers, and payload fields.
+
+## React `useStream`
+
+For React applications, use the TypeScript SDK's LangGraph client adapter with `@langchain/react`. `useStream` owns the thread, run, and state projection behavior while the Managed Deep Agents SDK handles auth, routes, and payload translation.
+
+```tsx
+import { Client } from "@langchain/managed-deepagents";
+import { useStream } from "@langchain/react";
+
+const agentId = "<agent_id>";
+
+const managedDeepAgents = new Client({
+  // Server-only or browser-safe proxy configuration.
+  // Do not ship LANGSMITH_API_KEY to browser clients.
+  apiKey: process.env.LANGSMITH_API_KEY,
+});
+
+const client = managedDeepAgents.getLangGraphClient({ agentId });
+
+export function ManagedDeepAgentStream() {
+  const stream = useStream({
+    client,
+    assistantId: agentId,
+    fetchStateHistory: false,
+  });
+
+  return (
+    <section>
+      <button
+        type="button"
+        disabled={stream.isLoading}
+        onClick={() => {
+          void stream.submit({
+            messages: [
+              { role: "user", content: "Write a short status update." },
+            ],
+          });
+        }}
+      >
+        Run agent
+      </button>
+
+      {stream.messages.map((message, index) => (
+        <p key={message.id ?? index}>{String(message.content)}</p>
+      ))}
+    </section>
+  );
+}
+```
+
+`stream.submit({ messages })` is the correct UI-level shape. The SDK adapter rewrites it to the Managed Deep Agents stream route as `input.messages`.
+
+## REST fallback
+
+Use REST when a client does not expose a field yet or when debugging raw payloads. Prefer SDK helpers in normal application code.
+
+Create an agent:
+
+```python
+import os
+import httpx
 
 BASE_URL = os.environ["DEEPAGENTS_BASE_URL"]
 HEADERS = {"X-Api-Key": os.environ["LANGSMITH_API_KEY"]}
 
-response = httpx.post(
-    f"{BASE_URL}/mcp-servers",
-    headers=HEADERS,
-    json={
-        "name": "tavily",
-        "url": "https://mcp.tavily.com/mcp/",
-        "headers": [
-            {"key": "Authorization", "value": "Bearer tvly-..."},
-        ],
-    },
-)
-response.raise_for_status()
-mcp_server_id = response.json()["id"]
-```
-
-Other operations on the same resource:
-
-| Action | Method + path |
-|--------|---------------|
-| List | `GET /mcp-servers` |
-| Get one | `GET /mcp-servers/{mcp_server_id}` |
-| Rotate credentials | `PATCH /mcp-servers/{mcp_server_id}` (replaces the **entire** `headers` array — partial diffs not supported) |
-| Delete | `DELETE /mcp-servers/{mcp_server_id}` |
-
-**Only static-header auth** (bearer tokens, custom API-key headers) is supported during preview. OAuth-backed MCP servers are planned.
-
-## Step 2 — Create the managed agent
-
-```python
 response = httpx.post(
     f"{BASE_URL}/agents",
     headers=HEADERS,
     json={
         "name": "research-assistant",
         "description": "Research assistant that can search the web and summarize sources.",
-        "runtime": {"model": {"model_id": "anthropic:claude-sonnet-4-6"}},
+        "runtime": {"model": {"model_id": "openai:gpt-5.5"}},
+        "backend": {"type": "state"},
         "instructions": (
             "You are a careful research assistant. Search for sources, "
             "keep notes, and return concise answers with citations."
         ),
-        "tools": {
-            "tools": [
-                {
-                    "name": "tavily_search",
-                    "mcp_server_url": "https://mcp.tavily.com/mcp/",
-                    "mcp_server_name": "tavily",
-                    "display_name": "tavily_search",
-                },
-            ],
-            "interrupt_config": {
-                "https://mcp.tavily.com/mcp/::tavily-search::tavily": False,
-            },
-        },
     },
 )
 response.raise_for_status()
 agent_id = response.json()["id"]
 ```
 
-Response includes the agent `id` (store it as `AGENT_ID`).
-
-Other operations:
-
-| Action | Method + path |
-|--------|---------------|
-| List | `GET /agents` |
-| Get one | `GET /agents/{agent_id}` |
-| Update | `PATCH /agents/{agent_id}` |
-| Delete | `DELETE /agents/{agent_id}` |
-
-**`PATCH` replaces `tools` wholesale** — to add a tool, pass the full new tool set, not just the additions. Each `PATCH` also creates a new `revision` on the agent's Context Hub repo.
-
-**Deleting an agent does NOT cascade to its threads.** Existing threads remain queryable but starting new runs returns `502`. Track and delete threads explicitly when cleaning up.
-
-### Supported models
-
-Pass model identifiers in `{provider}:{model_id}` form (e.g. `anthropic:claude-sonnet-4-6`, `openai:gpt-5.4-mini`). The runtime resolves models with `init_chat_model`, so any provider supported by `init_chat_model` works.
-
-Values **without** a colon are interpreted as references to a saved Playground configuration, not a model ID — always supply the full `{provider}:{model_id}` form when configuring a model directly.
-
-## Step 3 — Create a thread
-
-Threads preserve conversation and execution state for long-running work.
+Create a thread:
 
 ```python
 response = httpx.post(
@@ -205,17 +426,19 @@ response.raise_for_status()
 thread_id = response.json()["id"]
 ```
 
-## Step 4 — Stream a run
+Stream a run:
 
 ```python
 payload = {
     "agent_id": agent_id,
-    "messages": [
-        {
-            "role": "user",
-            "content": "Research recent approaches to agent memory and summarize the main tradeoffs.",
-        }
-    ],
+    "input": {
+        "messages": [
+            {
+                "role": "user",
+                "content": "Research recent approaches to agent memory and summarize the main tradeoffs.",
+            }
+        ]
+    },
     "stream_mode": ["values", "updates", "messages-tuple"],
     "stream_subgraphs": True,
     "user_timezone": "America/Los_Angeles",
@@ -234,13 +457,11 @@ with httpx.stream(
             print(line)
 ```
 
-Set `Accept: text/event-stream` so the client receives progress as SSE. `stream_mode` accepts the same values as the LangGraph runtime (`values`, `updates`, `messages-tuple`, etc.). `stream_subgraphs: true` emits events from subagent graphs as well as the parent.
+Set `Accept: text/event-stream` for raw REST streaming. `stream_mode` accepts LangGraph stream modes such as `values`, `updates`, and `messages-tuple`. `stream_subgraphs: true` emits subagent events as well as parent events.
 
-Every run is traced in LangSmith — model calls, tool calls, subagent activity, files, and runtime state are all inspectable from the trace UI.
+## Human-in-the-loop interrupts
 
-## Step 5 — Handle human-in-the-loop interrupts
-
-When `interrupt_config` flags a tool with `true`, the run pauses before the tool executes and the SSE stream emits an interrupt payload nested inside a `values` (or `updates`) event:
+When `interrupt_config` flags a tool with `true`, the run pauses before the tool executes and emits an interrupt payload inside a `values` or `updates` event:
 
 ```json
 {
@@ -249,110 +470,94 @@ When `interrupt_config` flags a tool with `true`, the run pauses before the tool
       "value": {
         "action_requests": [
           {
-            "name": "tavily_search",
-            "args": { "query": "…", "max_results": 5 },
-            "description": "Tool execution requires approval\n\nTool: tavily_search\nArgs: {...}"
+            "name": "read_url_content",
+            "args": { "url": "https://example.com" },
+            "description": "Tool execution requires approval"
           }
         ],
         "review_configs": [
           {
-            "action_name": "tavily_search",
+            "action_name": "read_url_content",
             "allowed_decisions": ["approve", "edit", "reject", "respond"]
           }
         ]
       },
-      "id": "7ae0be0e5105464d49a267e35083f422"
+      "id": "interrupt-id"
     }
   ]
 }
 ```
 
-The stream closes after the interrupt is emitted. To act on it, post a follow-up run with `command.resume` on the **same thread**:
+The stream closes after the interrupt is emitted. To act on it, post a follow-up run with `command.resume` on the same thread.
+
+Python SDK resume:
 
 ```python
-resume = httpx.stream(
-    "POST",
-    f"{BASE_URL}/threads/{thread_id}/runs/stream",
-    headers={**HEADERS, "Accept": "text/event-stream"},
-    json={
-        "agent_id": agent_id,
-        # The API requires a non-empty `messages` array on every call;
-        # an empty system message is accepted as a no-op when resuming.
-        "messages": [{"role": "system", "content": ""}],
-        "command": {
-            "resume": {
-                "decisions": [{"type": "approve"}]
-            }
-        },
-        "stream_mode": ["values", "updates", "messages-tuple"],
-        "stream_subgraphs": True,
-    },
-    timeout=None,
-)
+for event in client.threads.stream(
+    thread_id,
+    agent_id=agent_id,
+    messages=[{"role": "system", "content": ""}],
+    command={"resume": {"decisions": [{"type": "approve"}]}},
+    stream_mode=["values", "updates", "messages-tuple"],
+    stream_subgraphs=True,
+):
+    print(event.event, event.data)
 ```
 
-**The resume value must be the `HITLResponse` dict `{"decisions": [...]}` — not a bare list.** The middleware does `decisions = interrupt(request)["decisions"]` under the hood (see `langchain.agents.middleware.HumanInTheLoopMiddleware`), so a list at the top level crashes the run with `TypeError: list indices must be integers or slices, not str`.
+REST resume:
 
-Send exactly one decision per `action_request`, in the same order. Decision shapes:
+```python
+payload = {
+    "agent_id": agent_id,
+    "input": {"messages": [{"role": "system", "content": ""}]},
+    "command": {
+        "resume": {
+            "decisions": [{"type": "approve"}]
+        }
+    },
+    "stream_mode": ["values", "updates", "messages-tuple"],
+    "stream_subgraphs": True,
+}
+```
+
+The resume value must be the HITL response object `{"decisions": [...]}`, not a bare decision list. Send exactly one decision per `action_request`, in the same order.
 
 | Decision | Shape | Effect |
-|----------|-------|--------|
+| --- | --- | --- |
 | Approve | `{"type": "approve"}` | Run the tool with the proposed args. |
-| Edit | `{"type": "edit", "edited_action": {"name": "...", "args": {...}}}` | Run the tool with modified name/args (preserves the original `tool_call.id`). |
-| Reject | `{"type": "reject", "message": "..."}` | Block the tool. The model receives an error `ToolMessage` with `message` (or a default). |
-| Respond | `{"type": "respond", "message": "..."}` | Skip the tool; the model receives a success `ToolMessage` with `message` as the synthetic tool reply. |
+| Edit | `{"type": "edit", "edited_action": {"name": "...", "args": {...}}}` | Run the tool with modified name/args. |
+| Reject | `{"type": "reject", "message": "..."}` | Block the tool and return an error `ToolMessage` to the model. |
+| Respond | `{"type": "respond", "message": "..."}` | Skip the tool and return a synthetic successful tool reply. |
 
-Each entry's `type` must be present in the matching `review_configs[i].allowed_decisions` — otherwise the run raises `ValueError`.
+Each decision `type` must be allowed by the matching `review_configs[i].allowed_decisions`.
 
-### `POST /threads/{thread_id}/resolve-interrupt` (cancel, not approve)
+### Resolve interrupt endpoint
 
-There is also a `POST /v1/deepagents/threads/{thread_id}/resolve-interrupt` endpoint, which takes **no body** and returns `204`. It is **not** an approve shortcut — it calls `update_state(as_node="__end__")` on the upstream LangGraph runtime, which terminates the run at the interrupt without running the pending tool. Use it only when you want to abandon the paused work and free the thread; for any "approve / edit / reject / respond" decision, send a `command.resume` to `/runs/stream` instead.
-
-## JavaScript / cURL equivalents
-
-The same flow works with `fetch` (Node 18+ or browser) or `curl`. Replace `httpx.post(url, headers=HEADERS, json=...)` with:
-
-```javascript
-const BASE_URL = process.env.DEEPAGENTS_BASE_URL;
-const HEADERS = {
-  "X-Api-Key": process.env.LANGSMITH_API_KEY,
-  "Content-Type": "application/json",
-};
-
-const response = await fetch(`${BASE_URL}/agents`, {
-  method: "POST",
-  headers: HEADERS,
-  body: JSON.stringify({ /* same payload */ }),
-});
-if (!response.ok) throw new Error(await response.text());
-const { id: agentId } = await response.json();
-```
-
-For streaming, read from `response.body.pipeThrough(new TextDecoderStream()).getReader()`.
-
-For `curl`, set `--header "X-Api-Key: $LANGSMITH_API_KEY"` and `--header 'Content-Type: application/json'`.
+`POST /v1/deepagents/threads/{thread_id}/resolve-interrupt` takes no body and returns `204`. It terminates the paused run at the interrupt; it is not an approve shortcut. Use `command.resume` on `/runs/stream` for approve, edit, reject, or respond decisions.
 
 ## When NOT to use Managed Deep Agents
 
 Use a standard LangSmith Deployment via [[langgraph-cli]] (`langgraph deploy`) instead when you need:
-- Custom application code or custom routes around the agent
-- Advanced authentication
-- The full Agent Server API surface
-- Stronger isolation controls or maximum scalability
-- A region other than US LangSmith Cloud, or self-hosted/Hybrid
+
+- Custom application code or custom routes around the agent.
+- Advanced authentication around your own app server.
+- The full Agent Server API surface.
+- Stronger isolation controls or maximum scalability.
+- A region other than supported LangSmith Cloud regions, or self-hosted/Hybrid.
 
 ## Gotchas
 
-- **No SDK** — REST is the only supported interface. Python/JS/`useStream` SDK wrappers are in progress.
-- **No rate limits during preview** — but quotas may be introduced before GA; don't design around the absence of limits.
-- **`PATCH` is wholesale, not partial** — both for `agents` (`tools` field is replaced) and for `mcp-servers` (`headers` array is replaced). Always send the full new value.
-- **`interrupt_config` key format** — `{mcp_server_url}::{tool_name}` with two colons. Trailing slashes on the URL are stripped before matching.
-- **Tool name is the MCP tool name, not the server name** — if `tools[].name` doesn't match what the MCP server exposes from `tools/list`, the runtime silently drops the tool from the model's bound tool set. The model never sees it and never triggers the interrupt. List tools against the live server (e.g. via `mcp.client.streamable_http`) to confirm.
-- **Resume from an interrupt is `command.resume = {"decisions": [...]}`** — a bare list of decisions crashes the run with `TypeError: list indices must be integers or slices, not str` because the middleware does `interrupt(request)["decisions"]` internally.
-- **`/threads/{tid}/runs/stream` requires a non-empty `messages` array even when resuming** — pass `[{"role": "system", "content": ""}]` alongside `command.resume`.
-- **`/resolve-interrupt` advances to `__end__`** — the endpoint terminates the paused run without running the pending tool. It is a cancel/finalize escape hatch, not an approve.
-- **Model IDs must include the provider prefix** — `anthropic:claude-sonnet-4-6`, not `claude-sonnet-4-6` (the latter is treated as a Playground config reference).
-- **MCP credentials are sensitive** — `headers` is omitted from response bodies for callers without invoke permission; treat list/get responses as sensitive and avoid logging them verbatim.
-- **MCP auth limited to static headers** — bearer tokens and custom API-key headers only during preview. OAuth-backed registration is planned.
-- **Deleting an agent does not delete its threads** — and new runs on orphaned threads return `502`. Clean up threads explicitly.
-- **API stability** — routes live under `/v1/deepagents` but the surface may change in backwards-incompatible ways before GA. Breaking changes are communicated directly to preview customers.
+- **Use `deepagents-cli>=0.2.2`** - older CLI versions generate stale backend names.
+- **Use canonical backends** - new examples should use `state` or `sandbox` with `sandbox_config.scope`.
+- **REST stream payloads use `input.messages`** - SDK helpers accept `messages` and normalize the request body.
+- **Do not ship API keys to browsers** - proxy browser requests through your backend or custom `fetch`.
+- **`PATCH` can replace nested fields wholesale** - when updating tools, pass the full desired tool set.
+- **Tool names must match MCP tool names** - if `tools[].name` is wrong, the model will not see the tool.
+- **List tools before wiring `tools.json`** - use the CLI or SDK tool-listing methods to avoid name mismatches.
+- **Resume interrupts with `command.resume = {"decisions": [...]}`** - a bare list is invalid.
+- **Resume runs still need a non-empty message list** - use `[ {"role": "system", "content": ""} ]` as a no-op message when needed.
+- **`resolve-interrupt` cancels/finalizes** - it does not approve a pending action.
+- **Model IDs should include provider prefix** - use `openai:gpt-5.5`, not a bare model name.
+- **MCP credentials are sensitive** - avoid logging headers or raw credential payloads.
+- **Deleting an agent does not delete its threads** - track and clean up threads explicitly.
+- **API stability** - `/v1/deepagents` is still evolving; prefer SDK and CLI surfaces for user-facing workflows.


### PR DESCRIPTION
## Summary
- refresh the Managed Deep Agents skill for the CLI, Python/TypeScript SDKs, and React useStream
- update backend, MCP tool listing, REST stream payload, and interrupt guidance
- update skill catalog descriptions to stop framing MDA as REST-only

## Tests
- pnpm test
- rg stale Managed Deep Agents guidance