### PR TITLE
docs: rewrite managed-deep-agents skill for the code-first mda CLI

### DIFF
--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -25,7 +25,7 @@ This project uses skills that contain up-to-date patterns and working reference 
 - **deep-agents-core** - Invoke for Deep Agents harness architecture
 - **deep-agents-memory** - Invoke for long-term memory with StoreBackend
 - **deep-agents-orchestration** - Invoke for multi-agent coordination
-- **managed-deep-agents** - Invoke for Managed Deep Agents: deploy with the CLI, use the SDKs, stream runs, connect MCP tools, and build React `useStream` UIs
+- **managed-deep-agents** - Invoke for Managed Deep Agents: build a code-first agent, add tools, middleware, MCP connectors, schedules, and sandboxes, and deploy with the `mda` CLI
 
 ## Environment Setup
 

--- a/config/skills/managed-deep-agents/SKILL.md
+++ b/config/skills/managed-deep-agents/SKILL.md
@@ -1,563 +1,330 @@
 ---
 name: managed-deep-agents
-description: "INVOKE THIS SKILL when creating, deploying, running, or operating Managed Deep Agents in LangSmith. Covers deepagents-cli, the Python and TypeScript SDKs, React useStream, REST fallbacks, MCP tools, interrupts, backends, and the managed agent file tree."
+description: "INVOKE THIS SKILL when building, testing, or deploying Managed Deep Agents in LangSmith with the mda CLI. Covers the code-first, file-based project layout; define_deep_agent / defineDeepAgent; authored tools and middleware; MCP connectors; cron schedules; skills; sandboxes; mda init/dev/deploy; Context Hub; and human-in-the-loop interrupts in Python and TypeScript."
 ---
 
 # Managed Deep Agents
 
 ## Overview
 
-Managed Deep Agents is a hosted runtime for creating, running, and operating Deep Agents in LangSmith. It packages the operational layer around the open-source Deep Agents harness: a versioned Context Hub agent repo, durable threads, streamed runs, MCP credential storage, managed files, and optional LangSmith sandboxes.
+Managed Deep Agents is a hosted runtime for deploying and operating code-first Deep Agents in LangSmith. You author an agent in Python or TypeScript, then use the `mda` CLI to test it locally and deploy it to the managed runtime. It pairs the open-source Deep Agents harness (see [[deep-agents-core]]) with managed infrastructure: durable runs, LangSmith sandboxes, Context Hub-backed instructions, skills, memory, traces, and hosted LangGraph deployment.
 
-Use the Managed Deep Agents path when the user wants LangSmith to host and operate the agent. For self-hosted deployments, custom application routes, or the full Agent Server API surface, use a standard LangSmith Deployment via [[langgraph-cli]] instead.
+The core idea is that **an agent is a directory**. A file's location determines its role, and the CLI compiles that directory into a managed LangGraph app. There is no API-driven create/update/invoke flow during private beta: you write code and run `mda deploy`.
 
 ## When to use
 
 Use this skill when the user wants to:
 
-- Deploy a Managed Deep Agent from local project files.
-- Create or update a Managed Deep Agent from Python, TypeScript, or REST.
-- Run an agent on a durable thread and stream output.
-- Build a React chat UI with `@langchain/react` `useStream`.
-- Register MCP servers, list MCP tools, or configure tool interrupts.
-- Choose between Managed Deep Agents and a self-hosted LangSmith Deployment.
+- Build a Deep Agent in code (Python or TypeScript) and deploy it to LangSmith without standing up their own server.
+- Add authored tools, middleware, MCP connectors, cron schedules, skills, or a sandbox to a managed agent.
+- Test an agent locally with `mda dev` and deploy it with `mda deploy`.
+- Understand what the managed runtime owns versus what the author configures.
+
+Use a standard LangSmith Deployment (see [[langgraph-cli]], `langgraph deploy`) instead when the user needs custom application code, custom routes, advanced authentication, stronger isolation, maximum scalability, or a region other than US LangSmith Cloud.
 
 ## Prerequisites
 
-- Managed Deep Agents preview access in the target LangSmith workspace.
+- Managed Deep Agents private beta access in the target LangSmith workspace.
 - A LangSmith API key for that workspace.
-- One of the supported clients:
+- Python and `uv` for Python projects, or Node.js and npm for TypeScript projects.
+- A model provider API key.
+
+Install the `mda` CLI. Both packages ship the same CLI:
 
 ```bash
-uv tool install "deepagents-cli>=0.2.2"
-pip install managed-deepagents
-npm install @langchain/managed-deepagents @langchain/react
+pip install --pre managed-deepagents        # Python
+npm install -g managed-deepagents@dev        # TypeScript
 ```
 
-Set the API key in the shell or server environment:
+Set the LangSmith API key in the project `.env` or the shell:
 
 ```bash
 export LANGSMITH_API_KEY="<LANGSMITH_API_KEY>"
 ```
 
-The SDKs default to `https://api.smith.langchain.com/v1/deepagents`. To use a different compatible endpoint, set `LANGSMITH_ENDPOINT` or pass `api_url` / `apiUrl` in the client.
+Managed Deep Agents is CLI-first during private beta and runs on US LangSmith Cloud only. Self-hosted and Hybrid are not supported.
 
-For direct REST examples, set:
+## Project layout
 
-```bash
-export DEEPAGENTS_BASE_URL="https://api.smith.langchain.com/v1/deepagents"
-```
-
-All REST requests authenticate with:
-
-```text
-X-Api-Key: <LANGSMITH_API_KEY>
-```
-
-Never expose a long-lived LangSmith API key in browser code. For browser apps, route requests through your own backend or provide a custom `fetch` implementation that proxies requests server-side.
-
-## Choose an interface
-
-| Interface | Use for |
-| --- | --- |
-| `deepagents-cli>=0.2.2` | Normal project-file workflow: scaffold, edit files, deploy, manage MCP servers. |
-| Python SDK `managed-deepagents` | Server-side Python automation, tests, scripts, services, and streaming. |
-| TypeScript SDK `@langchain/managed-deepagents` | Server-side TypeScript automation and LangGraph-compatible streaming. |
-| React `useStream` | Chat UIs that should let LangGraph own thread/run/projection state. |
-| REST `/v1/deepagents` | Low-level fallback when a client does not expose a field yet. |
-
-Prefer the CLI for local agent projects. Prefer the SDKs for application code. Use REST only when you need exact request control.
-
-## Resource groups
-
-| Group | Purpose |
-| --- | --- |
-| Agents | Create, list, get, update, clone, delete, and health-check Managed Deep Agents. |
-| Threads | Create, list, search, count, inspect, update, and delete durable thread state. |
-| Runs | Start and stream runs on a thread. |
-| MCP servers | Register, list, update, delete, and connect MCP servers. |
-| MCP tools | List tools exposed by a registered MCP server for `tools.json`. |
-| Auth sessions | Start and inspect OAuth authorization sessions. |
-
-## Project file tree
-
-The CLI uses a local project directory and deploys it into the managed Context Hub agent repo.
+The path passed to `mda dev` or `mda deploy` is the project root. A file's location determines its role:
 
 ```text
 my-agent/
-  agent.json
-  AGENTS.md
-  tools.json
-  skills/<name>/SKILL.md
-  subagents/<name>/agent.json
-  subagents/<name>/AGENTS.md
-  subagents/<name>/tools.json
+  agent.py | agent.ts | agent.tsx          # Required: exports the named `agent`
+  instructions.md                          # Managed system prompt, synced to Context Hub
+  pyproject.toml | package.json            # Project dependencies
+  .env                                     # Deploy auth + runtime secrets (never archived)
+  tools/                                   # Authored LangChain tools the agent imports
+  middleware/                              # Authored middleware the agent imports
+  connectors/mcp.py | connectors/mcp.ts    # Remote MCP server declarations
+  schedules/<name>.py | <name>.ts          # Managed cron schedules
+  skills/<name>/SKILL.md                   # Deploy-owned skills, synced to Context Hub
+  sandbox/__init__.py | sandbox/index.ts   # Managed sandbox configuration
+  sandbox/setup.sh                         # Sandbox provisioning script (runs once)
 ```
 
-| File / directory | Purpose |
-| --- | --- |
-| `agent.json` | Agent name, description, model, backend, permissions, and optional target `agent_id`. |
-| `AGENTS.md` | Main agent instructions. |
-| `tools.json` | MCP-backed tools plus `interrupt_config`. |
-| `skills/` | Reusable instructions and files the agent can load. |
-| `subagents/` | Delegated worker definitions and optional subagent-scoped tools. |
+Only the agent entry is required. It must export a named `agent` created with `define_deep_agent` / `defineDeepAgent`. The `tools/` and `middleware/` folders are conventions, not special registries: MDA copies project files verbatim, so any local module the agent imports works. The other files take on managed meanings when present.
 
-At runtime, the agent can read and write managed files, including memory files created by the Deep Agents harness.
+Scaffold a project with `mda init <name>`; the CLI detects the language from `pyproject.toml` or `package.json`, or prompts.
 
-## Backends
+## Define the agent
 
-New projects should use the canonical backend names from `deepagents-cli>=0.2.2`.
+The agent entry returns a pre-runtime spec, not a compiled graph. The managed runtime injects the backend, store, checkpointer, memory, skills, and system prompt at deploy time, so do not set those.
 
-Use `state` when the agent does not need sandbox-specific backend behavior:
+```python
+# agent.py
+from managed_deepagents import define_deep_agent
 
-```json
-{
-  "backend": {
-    "type": "state"
-  }
-}
+from tools.query_db import query_db
+
+agent = define_deep_agent(
+    model="openai:gpt-5.5",
+    tools=[query_db],
+)
 ```
 
-Use `sandbox` when the agent needs a LangSmith sandbox for code execution, filesystem work, or long-running tasks:
+```ts
+// agent.ts
+import { defineDeepAgent } from "managed-deepagents";
 
-```json
-{
-  "backend": {
-    "type": "sandbox",
-    "sandbox_config": {
-      "scope": "thread",
-      "policy_ids": ["policy-id"],
-      "idle_ttl_seconds": 900,
-      "delete_after_stop_seconds": 300
-    }
-  }
-}
+import { queryDB } from "./tools/query-db";
+
+export const agent = defineDeepAgent({
+  model: "openai:gpt-5.5",
+  tools: [queryDB],
+});
 ```
 
-`sandbox_config.scope` must be `thread` or `agent`.
+**Author-set fields:** `model`, `tools`, `middleware`, `subagents`, `permissions`, `interrupt_on` / `interruptOn`, `response_format` / `responseFormat`, `context_schema` / `contextSchema`, `name`, `cache`, `debug`, `disable_memory` / `disableMemory`.
 
-## CLI workflow
+**Managed fields (do not set):** `backend`, `store`, `checkpointer`, `memory`, `skills`, `system_prompt` / `systemPrompt`. Configure the system prompt in `instructions.md`, connectors in `connectors/mcp.*`, schedules in `schedules/**`, skills in `skills/**`, and the sandbox under `sandbox/`.
 
-Use the CLI for most deploy workflows.
+Model identifiers use the `{provider}:{model_id}` form, for example `openai:gpt-5.5`. The runtime resolves them with `init_chat_model`, so any `init_chat_model` provider works.
 
-```bash
-deepagents init research-assistant
-cd research-assistant
+## Instructions
+
+Put the system prompt in `instructions.md` next to the agent entry:
+
+```markdown
+# Research assistant
+
+You are a careful research assistant. Find sources, keep notes, and return
+concise answers with citations.
 ```
 
-Edit `agent.json`:
+`mda dev` embeds it into the generated local entry. `mda deploy` syncs it to Context Hub, and the deployed runtime reads it from there.
 
-```json
-{
-  "name": "research-assistant",
-  "description": "Research assistant that can search the web and summarize sources.",
-  "model": "openai:gpt-5.5",
-  "backend": {
-    "type": "state"
-  }
-}
+## Authored tools
+
+Define tools in the project and import them into the agent entry. The runtime keeps authored tools in the bounded agent execution surface.
+
+```python
+# tools/query_db.py
+from langchain.tools import tool
+
+
+@tool(parse_docstring=True)
+def query_db(query: str) -> str:
+    """Run a read-only SQL query against the application database.
+
+    Args:
+        query: A read-only SQL query to execute.
+    """
+    return f"Ran query: {query}"
 ```
 
-Edit `AGENTS.md` with the main instructions, then deploy:
+```ts
+// tools/query-db.ts
+import { tool } from "langchain";
+import { z } from "zod";
 
-```bash
-deepagents deploy
+export const queryDB = tool(
+  async ({ query }) => `Ran query: ${query}`,
+  {
+    name: "query_db",
+    description: "Run a read-only SQL query against the application database.",
+    schema: z.object({ query: z.string().describe("A read-only SQL query.") }),
+  },
+);
 ```
 
-Useful CLI commands:
+Tools read deployment secrets from environment variables. Put local values in `.env`; deploy forwards non-reserved `.env` values as hosted secrets.
+
+## Middleware
+
+Middleware wraps model and tool calls for cross-cutting behavior (logging, PII redaction, retries, limits). Order is explicit in the `middleware` list; MDA never infers it. Pass prebuilt LangChain middleware or author your own (see [[langchain-middleware]]).
+
+```python
+# agent.py
+from langchain.agents.middleware import ModelCallLimitMiddleware, PIIMiddleware
+from managed_deepagents import define_deep_agent
+
+agent = define_deep_agent(
+    model="openai:gpt-5.5",
+    middleware=[
+        PIIMiddleware("email", strategy="redact"),
+        ModelCallLimitMiddleware(run_limit=50),
+    ],
+)
+```
+
+```ts
+// agent.ts
+import { defineDeepAgent } from "managed-deepagents";
+import { modelCallLimitMiddleware, piiMiddleware } from "langchain";
+
+export const agent = defineDeepAgent({
+  model: "openai:gpt-5.5",
+  middleware: [
+    piiMiddleware("email", { strategy: "redact" }),
+    modelCallLimitMiddleware({ runLimit: 50 }),
+  ],
+});
+```
+
+## MCP connectors
+
+Declare remote MCP servers in `connectors/mcp.py` or `connectors/mcp.ts` with a named `mcp` export. MDA loads their tools at runtime and appends them to authored tools, prefixing tool names with the server name by default.
+
+```python
+# connectors/mcp.py
+from managed_deepagents.connectors import define_mcp_servers
+
+mcp = define_mcp_servers(
+    mcp_servers={
+        "langchainDocs": {"transport": "http", "url": "https://docs.langchain.com/mcp"},
+    },
+)
+```
+
+```ts
+// connectors/mcp.ts
+import { defineMcpServers } from "managed-deepagents";
+
+export const mcp = defineMcpServers({
+  mcpServers: {
+    langchainDocs: { transport: "http", url: "https://docs.langchain.com/mcp" },
+  },
+});
+```
+
+Only remote `http` and `sse` transports are supported. Stdio servers are rejected. Configuration is validated eagerly at build or dev startup. Store any OAuth or header tokens in `.env` and reference them from the connector.
+
+## Schedules
+
+Declare managed cron schedules under `schedules/`, one named `schedule` export per file. Deploy reconciles them into LangSmith cron jobs after the deployment is live.
+
+```python
+# schedules/daily_digest.py
+from managed_deepagents import define_schedule
+
+schedule = define_schedule(
+    cron="0 8 * * 1-5",
+    timezone="America/Los_Angeles",
+    prompt="Summarize what you learned yesterday and list open questions.",
+)
+```
+
+```ts
+// schedules/daily-digest.ts
+import { defineSchedule } from "managed-deepagents";
+
+export const schedule = defineSchedule({
+  cron: "0 8 * * 1-5",
+  timezone: "America/Los_Angeles",
+  prompt: "Summarize what you learned yesterday and list open questions.",
+});
+```
+
+Provide either `prompt` or a structured `input`, not both. Set `thread.mode` to `ephemeral` (cleaned up after the run) or `persistent` (reuses a stable `thread.id` so state accumulates). Schedule declarations must be static literals, not values computed from env vars or function calls.
+
+## Sandboxes
+
+Configure a sandbox when the agent needs isolated code execution or filesystem work. Export `sandbox` from `sandbox/index.ts` or `sandbox/__init__.py`.
+
+```python
+# sandbox/__init__.py
+from managed_deepagents import define_sandbox
+from deepagents.backends import LangSmithSandbox
+
+sandbox = define_sandbox(
+    LangSmithSandbox,
+    scope="thread",
+    idle_ttl_seconds=600,
+    default_timeout=600,
+)
+```
+
+```ts
+// sandbox/index.ts
+import { defineSandbox } from "managed-deepagents";
+import { LangSmithSandbox } from "deepagents";
+
+export const sandbox = defineSandbox(LangSmithSandbox, {
+  scope: "thread",
+  idleTtlSeconds: 600,
+  defaultTimeout: 600,
+});
+```
+
+`scope` is `thread` (one sandbox per conversation) or `agent`. If `sandbox/setup.sh` exists, MDA runs it once when a new sandbox is provisioned. During `mda dev`, the runtime falls back to a local temp-directory sandbox when provider credentials are unavailable; the fallback is for development only.
+
+## Skills
+
+Put deploy-owned skills under `skills/<name>/SKILL.md`. Deploy syncs `skills/**` to Context Hub and deletes deployed skills that no longer exist locally. Each skill is a markdown file with `name` and `description` frontmatter that the agent loads on demand.
+
+## CLI commands
 
 | Command | Use |
 | --- | --- |
-| `deepagents --version` | Confirm `deepagents-cli>=0.2.2`. |
-| `deepagents deploy --dry-run` | Print the agent payload and managed file tree without deploying. |
-| `deepagents agents list` | List Managed Deep Agents in the workspace. |
-| `deepagents agents get <agent_id> --include-files` | Inspect an agent and its managed files. |
-| `deepagents mcp-servers add --url URL --name NAME` | Register a static-header MCP server. |
-| `deepagents mcp-servers add --url URL --auth-type oauth --connect` | Register and connect an OAuth MCP server. |
-| `deepagents mcp-servers tools <id|name|url>` | List tools and print a paste-ready `tools.json` snippet. |
-| `deepagents mcp-servers connect <id|name|url>` | Complete OAuth for a registered OAuth MCP server. |
+| `mda init <name>` | Scaffold a Python or TypeScript project. |
+| `mda dev [path]` | Compile into `.mda/build` and run the local LangGraph dev server in LangSmith Studio. Flags: `--port`, `--hostname`, `--browser`, `--no-reload`. |
+| `mda deploy [path]` | Compile, sync Context Hub, upload, and deploy. Flags: `--name`, `--deployment-type dev\|prod`, `--tenant-id`, `--host-url`, `--no-wait`. |
 
-For shared repositories, put the target `agent_id` in `agent.json`; the CLI asks for confirmation before updating that remote agent. Use `--yes` only when the target is intentional.
+For Python projects, run `uv sync` inside the generated project before `mda dev`. Authentication resolves in order: `LANGGRAPH_HOST_API_KEY`, `LANGSMITH_API_KEY`, `LANGCHAIN_API_KEY`, read from `.env` first, then the shell.
 
-## MCP tools
+## Deploy and Context Hub
 
-Tools are configured with a `tools` array and an `interrupt_config` map. The same shape is used in `tools.json` and inline SDK/REST create or update payloads.
+`mda deploy` compiles the project into `.mda/build` (copying your code verbatim, generating a managed LangGraph entry, excluding `node_modules`, `.git`, `.mda`, `memories`, `dist`, `build`, and `.env*`), then:
 
-```json
-{
-  "tools": [
-    {
-      "name": "read_url_content",
-      "mcp_server_url": "https://example.com/mcp",
-      "mcp_server_name": "my-tools",
-      "display_name": "read_url_content"
-    }
-  ],
-  "interrupt_config": {
-    "https://example.com/mcp::read_url_content": false
-  }
-}
-```
+1. Resolves the LangSmith key and verifies the model provider key is available.
+2. Forwards non-reserved `.env` values (provider keys, MCP tokens, database URLs) as hosted deployment secrets. The `.env` file is never uploaded.
+3. Syncs `instructions.md` and `skills/**` to the deployment's Context Hub repo, preserving runtime memory.
+4. Uploads the build, triggers a hosted build, and waits until the revision is `DEPLOYED` (unless `--no-wait`).
+5. Reconciles managed cron jobs from `schedules/**`.
 
-- `tools[].mcp_server_url` must match a registered workspace MCP server URL.
-- `tools[].name` is the tool name exposed by the MCP server, not the workspace MCP-server display name.
-- Use `deepagents mcp-servers tools <server>` or the SDK tool-listing methods to confirm exact tool names.
-- `interrupt_config` keys use `{mcp_server_url}::{tool_name}`. Additional `::` parts are accepted for compatibility, but do not rely on them for new configs.
-- Set the interrupt value to `true` to require human approval before the tool runs.
+Context Hub stores `/instructions.md` and `/skills/**` (deploy-owned) and `/memories/AGENTS.md` (runtime-owned, durable across deploys). Set `disable_memory=True` / `disableMemory: true` to turn off managed agent memory.
 
-Python SDK tool listing:
+Inspect build status, revisions, and traces on the deployment page in LangSmith.
+
+## Human-in-the-loop
+
+Pause before sensitive tool calls with `interrupt_on` / `interruptOn` (and gate access with `permissions`). See [[langgraph-human-in-the-loop]] for interrupt and resume semantics.
 
 ```python
-from managed_deepagents import Client
-
-with Client() as client:
-    tools = client.mcp_servers.list_tools(
-        url="https://example.com/mcp",
-        force_refresh=True,
-    )
-    print(tools["tools"])
+agent = define_deep_agent(
+    model="openai:gpt-5.5",
+    tools=[query_db],
+    interrupt_on={"query_db": True},
+)
 ```
-
-TypeScript SDK tool listing:
 
 ```ts
-import { Client } from "@langchain/managed-deepagents";
-
-const client = new Client({ apiKey: process.env.LANGSMITH_API_KEY });
-const tools = await client.mcpServers.listTools({
-  url: "https://example.com/mcp",
-  forceRefresh: true,
-});
-console.log(tools.tools);
-```
-
-## Python SDK workflow
-
-Use the Python SDK for server-side automation and streaming.
-
-```python
-from managed_deepagents import Client
-
-with Client() as client:
-    agent = client.agents.create(
-        name="research-assistant",
-        description="Research assistant that can search the web and summarize sources.",
-        model="openai:gpt-5.5",
-        backend={"type": "state"},
-        instructions=(
-            "You are a careful research assistant. Search for sources, "
-            "keep notes, and return concise answers with citations."
-        ),
-    )
-
-    thread = client.threads.create(
-        agent_id=agent["id"],
-        options={
-            "test_run": False,
-            "skip_memory_write_protection": False,
-        },
-    )
-
-    for event in client.threads.stream(
-        thread["id"],
-        agent_id=agent["id"],
-        messages=[
-            {
-                "role": "user",
-                "content": "Research recent approaches to agent memory and summarize the main tradeoffs.",
-            }
-        ],
-        stream_mode=["values", "updates", "messages-tuple"],
-        stream_subgraphs=True,
-        user_timezone="America/Los_Angeles",
-    ):
-        print(event.event, event.data)
-```
-
-Async Python clients are available as `AsyncClient` with matching resource names.
-
-## TypeScript SDK workflow
-
-Use the TypeScript SDK for server-side automation and LangGraph-compatible streaming.
-
-```ts
-import { Client } from "@langchain/managed-deepagents";
-
-const client = new Client({
-  apiKey: process.env.LANGSMITH_API_KEY,
-});
-
-const agent = await client.agents.create({
-  name: "research-assistant",
-  description: "Research assistant that can search the web and summarize sources.",
+export const agent = defineDeepAgent({
   model: "openai:gpt-5.5",
-  backend: { type: "state" },
-  instructions:
-    "You are a careful research assistant. Search for sources, keep notes, and return concise answers with citations.",
+  tools: [queryDB],
+  interruptOn: { query_db: true },
 });
-
-const thread = await client.threads.create({
-  agent_id: agent.id,
-  options: {
-    test_run: false,
-    skip_memory_write_protection: false,
-  },
-});
-
-const langGraphClient = client.getLangGraphClient({ agentId: agent.id });
-const stream = langGraphClient.runs.stream(thread.id, agent.id, {
-  input: {
-    messages: [
-      {
-        role: "user",
-        content:
-          "Research recent approaches to agent memory and summarize the main tradeoffs.",
-      },
-    ],
-  },
-  streamMode: ["values", "updates", "messages-tuple"],
-  streamSubgraphs: true,
-});
-
-for await (const event of stream) {
-  console.log(event.event, event.data);
-}
 ```
 
-The adapter translates LangGraph SDK request fields into Managed Deep Agents routes, headers, and payload fields.
-
-## React `useStream`
-
-For React applications, use the TypeScript SDK's LangGraph client adapter with `@langchain/react`. `useStream` owns the thread, run, and state projection behavior while the Managed Deep Agents SDK handles auth, routes, and payload translation.
-
-```tsx
-import { Client } from "@langchain/managed-deepagents";
-import { useStream } from "@langchain/react";
-
-const agentId = "<agent_id>";
-
-const managedDeepAgents = new Client({
-  // Server-only or browser-safe proxy configuration.
-  // Do not ship LANGSMITH_API_KEY to browser clients.
-  apiKey: process.env.LANGSMITH_API_KEY,
-});
-
-const client = managedDeepAgents.getLangGraphClient({ agentId });
-
-export function ManagedDeepAgentStream() {
-  const stream = useStream({
-    client,
-    assistantId: agentId,
-    fetchStateHistory: false,
-  });
-
-  return (
-    <section>
-      <button
-        type="button"
-        disabled={stream.isLoading}
-        onClick={() => {
-          void stream.submit({
-            messages: [
-              { role: "user", content: "Write a short status update." },
-            ],
-          });
-        }}
-      >
-        Run agent
-      </button>
-
-      {stream.messages.map((message, index) => (
-        <p key={message.id ?? index}>{String(message.content)}</p>
-      ))}
-    </section>
-  );
-}
-```
-
-`stream.submit({ messages })` is the correct UI-level shape. The SDK adapter rewrites it to the Managed Deep Agents stream route as `input.messages`.
-
-## REST fallback
-
-Use REST when a client does not expose a field yet or when debugging raw payloads. Prefer SDK helpers in normal application code.
-
-Create an agent:
-
-```python
-import os
-import httpx
-
-BASE_URL = os.environ["DEEPAGENTS_BASE_URL"]
-HEADERS = {"X-Api-Key": os.environ["LANGSMITH_API_KEY"]}
-
-response = httpx.post(
-    f"{BASE_URL}/agents",
-    headers=HEADERS,
-    json={
-        "name": "research-assistant",
-        "description": "Research assistant that can search the web and summarize sources.",
-        "runtime": {"model": {"model_id": "openai:gpt-5.5"}},
-        "backend": {"type": "state"},
-        "instructions": (
-            "You are a careful research assistant. Search for sources, "
-            "keep notes, and return concise answers with citations."
-        ),
-    },
-)
-response.raise_for_status()
-agent_id = response.json()["id"]
-```
-
-Create a thread:
-
-```python
-response = httpx.post(
-    f"{BASE_URL}/threads",
-    headers=HEADERS,
-    json={
-        "agent_id": agent_id,
-        "options": {
-            "test_run": False,
-            "skip_memory_write_protection": False,
-        },
-    },
-)
-response.raise_for_status()
-thread_id = response.json()["id"]
-```
-
-Stream a run:
-
-```python
-payload = {
-    "agent_id": agent_id,
-    "input": {
-        "messages": [
-            {
-                "role": "user",
-                "content": "Research recent approaches to agent memory and summarize the main tradeoffs.",
-            }
-        ]
-    },
-    "stream_mode": ["values", "updates", "messages-tuple"],
-    "stream_subgraphs": True,
-    "user_timezone": "America/Los_Angeles",
-}
-
-with httpx.stream(
-    "POST",
-    f"{BASE_URL}/threads/{thread_id}/runs/stream",
-    headers={**HEADERS, "Accept": "text/event-stream"},
-    json=payload,
-    timeout=None,
-) as response:
-    response.raise_for_status()
-    for line in response.iter_lines():
-        if line:
-            print(line)
-```
-
-Set `Accept: text/event-stream` for raw REST streaming. `stream_mode` accepts LangGraph stream modes such as `values`, `updates`, and `messages-tuple`. `stream_subgraphs: true` emits subagent events as well as parent events.
-
-## Human-in-the-loop interrupts
-
-When `interrupt_config` flags a tool with `true`, the run pauses before the tool executes and emits an interrupt payload inside a `values` or `updates` event:
-
-```json
-{
-  "__interrupt__": [
-    {
-      "value": {
-        "action_requests": [
-          {
-            "name": "read_url_content",
-            "args": { "url": "https://example.com" },
-            "description": "Tool execution requires approval"
-          }
-        ],
-        "review_configs": [
-          {
-            "action_name": "read_url_content",
-            "allowed_decisions": ["approve", "edit", "reject", "respond"]
-          }
-        ]
-      },
-      "id": "interrupt-id"
-    }
-  ]
-}
-```
-
-The stream closes after the interrupt is emitted. To act on it, post a follow-up run with `command.resume` on the same thread.
-
-Python SDK resume:
-
-```python
-for event in client.threads.stream(
-    thread_id,
-    agent_id=agent_id,
-    messages=[{"role": "system", "content": ""}],
-    command={"resume": {"decisions": [{"type": "approve"}]}},
-    stream_mode=["values", "updates", "messages-tuple"],
-    stream_subgraphs=True,
-):
-    print(event.event, event.data)
-```
-
-REST resume:
-
-```python
-payload = {
-    "agent_id": agent_id,
-    "input": {"messages": [{"role": "system", "content": ""}]},
-    "command": {
-        "resume": {
-            "decisions": [{"type": "approve"}]
-        }
-    },
-    "stream_mode": ["values", "updates", "messages-tuple"],
-    "stream_subgraphs": True,
-}
-```
-
-The resume value must be the HITL response object `{"decisions": [...]}`, not a bare decision list. Send exactly one decision per `action_request`, in the same order.
-
-| Decision | Shape | Effect |
-| --- | --- | --- |
-| Approve | `{"type": "approve"}` | Run the tool with the proposed args. |
-| Edit | `{"type": "edit", "edited_action": {"name": "...", "args": {...}}}` | Run the tool with modified name/args. |
-| Reject | `{"type": "reject", "message": "..."}` | Block the tool and return an error `ToolMessage` to the model. |
-| Respond | `{"type": "respond", "message": "..."}` | Skip the tool and return a synthetic successful tool reply. |
-
-Each decision `type` must be allowed by the matching `review_configs[i].allowed_decisions`.
-
-### Resolve interrupt endpoint
-
-`POST /v1/deepagents/threads/{thread_id}/resolve-interrupt` takes no body and returns `204`. It terminates the paused run at the interrupt; it is not an approve shortcut. Use `command.resume` on `/runs/stream` for approve, edit, reject, or respond decisions.
-
-## When NOT to use Managed Deep Agents
-
-Use a standard LangSmith Deployment via [[langgraph-cli]] (`langgraph deploy`) instead when you need:
-
-- Custom application code or custom routes around the agent.
-- Advanced authentication around your own app server.
-- The full Agent Server API surface.
-- Stronger isolation controls or maximum scalability.
-- A region other than supported LangSmith Cloud regions, or self-hosted/Hybrid.
+When a run hits an interrupt, it pauses. During `mda dev`, respond to it in LangSmith Studio. On a deployed agent, resume through the LangGraph server API with a `Command(resume=...)` payload. During private beta, programmatic invocation from your own application is contact-your-team.
 
 ## Gotchas
 
-- **Use `deepagents-cli>=0.2.2`** - older CLI versions generate stale backend names.
-- **Use canonical backends** - new examples should use `state` or `sandbox` with `sandbox_config.scope`.
-- **REST stream payloads use `input.messages`** - SDK helpers accept `messages` and normalize the request body.
-- **Do not ship API keys to browsers** - proxy browser requests through your backend or custom `fetch`.
-- **`PATCH` can replace nested fields wholesale** - when updating tools, pass the full desired tool set.
-- **Tool names must match MCP tool names** - if `tools[].name` is wrong, the model will not see the tool.
-- **List tools before wiring `tools.json`** - use the CLI or SDK tool-listing methods to avoid name mismatches.
-- **Resume interrupts with `command.resume = {"decisions": [...]}`** - a bare list is invalid.
-- **Resume runs still need a non-empty message list** - use `[ {"role": "system", "content": ""} ]` as a no-op message when needed.
-- **`resolve-interrupt` cancels/finalizes** - it does not approve a pending action.
-- **Model IDs should include provider prefix** - use `openai:gpt-5.5`, not a bare model name.
-- **MCP credentials are sensitive** - avoid logging headers or raw credential payloads.
-- **Deleting an agent does not delete its threads** - track and clean up threads explicitly.
-- **API stability** - `/v1/deepagents` is still evolving; prefer SDK and CLI surfaces for user-facing workflows.
+- **Use the `mda` CLI**, not the older `deepagents` CLI or the removed `Client` SDK / `/v1/deepagents` REST surface. During private beta there is no public create/update/invoke API.
+- **Do not set managed fields** (`backend`, `store`, `checkpointer`, `memory`, `skills`, system prompt) in the agent definition; the runtime owns them.
+- **Model IDs need the provider prefix**: `openai:gpt-5.5`, not a bare model name.
+- **MCP connectors support `http` and `sse` only**; stdio is rejected, and misconfiguration surfaces at build or dev startup.
+- **`.env` is never archived**; deploy forwards non-reserved values as hosted secrets. Do not commit real secrets.
+- **Schedule declarations must be static literals**; the compiler extracts them without running your code.
+- **Private beta scope**: US LangSmith Cloud only, CLI-first. Self-hosted and Hybrid are not supported.


### PR DESCRIPTION
Rewrites the `managed-deep-agents` skill for the current code-first, file-based `mda` iteration and removes the old API-driven surface.

## Changes
- Replace `deepagents-cli`, the `Client` SDK, `/v1/deepagents` REST, and React `useStream` with the code-first `mda` CLI flow
- Document the project layout, `define_deep_agent`/`defineDeepAgent`, tools, middleware, MCP connectors, schedules, sandboxes, and skills (Python + TypeScript)
- Cover `mda init/dev/deploy`, Context Hub, and human-in-the-loop via `interrupt_on`
- Update the `AGENTS.md` skill description to match

## Verification
- Cross-refs resolve, description within limits, no stale API terms
- `npm test` passes (172)
