### PR TITLE
Add package-language local quickstart skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ Use eval-engineering to inspect this agent and propose two or three Harbor evals
 - **langchain-dependencies** - Full package version and dependency management reference (Python + TypeScript)
 
 ### Quickstarts (local)
-Minimal “get something running” skills — ask for provider/model (default `anthropic:claude-sonnet-5`), provider API key only:
-- **langchain-python-quickstart** / **langchain-typescript-quickstart** — weather stub + `create_agent` / `createAgent`
-- **langgraph-python-quickstart** / **langgraph-typescript-quickstart** — weather stub + minimal `StateGraph`
-- **deepagents-python-quickstart** / **deepagents-typescript-quickstart** — research agent with **provider-native web search** (no Tavily)
+Thin wrappers around the official Mintlify quickstarts — ask for provider/model (default `anthropic:claude-sonnet-5`), new directory, provider API key only:
+- **langchain-python-quickstart** / **langchain-typescript-quickstart** → [Python](https://docs.langchain.com/oss/python/langchain/quickstart) / [JS](https://docs.langchain.com/oss/javascript/langchain/quickstart) (weather)
+- **langgraph-python-quickstart** / **langgraph-typescript-quickstart** → [Python](https://docs.langchain.com/oss/python/langgraph/quickstart) / [JS](https://docs.langchain.com/oss/javascript/langgraph/quickstart) (math)
+- **deepagents-python-quickstart** / **deepagents-typescript-quickstart** → [Python](https://docs.langchain.com/oss/python/deepagents/quickstart) / [JS](https://docs.langchain.com/oss/javascript/deepagents/quickstart) (research; provider web search instead of Tavily)
 
 ### Deep Agents
 - **deep-agents-core** - Agent architecture, harness setup, and SKILL.md format

--- a/README.md
+++ b/README.md
@@ -104,11 +104,17 @@ Then ask your coding agent:
 Use eval-engineering to inspect this agent and propose two or three Harbor evals. Traces for this agent can be found here [Tracing Project/Location].
 ```
 
-## Available Skills (15)
+## Available Skills (21)
 
 ### Getting Started
 - **ecosystem-primer** - Start-here primer: framework selection (LangChain vs LangGraph vs Deep Agents), env setup, and which skill to load next
 - **langchain-dependencies** - Full package version and dependency management reference (Python + TypeScript)
+
+### Quickstarts (local)
+Minimal “get something running” skills — ask for provider/model (default `anthropic:claude-sonnet-5`), provider API key only:
+- **langchain-python-quickstart** / **langchain-typescript-quickstart** — weather stub + `create_agent` / `createAgent`
+- **langgraph-python-quickstart** / **langgraph-typescript-quickstart** — weather stub + minimal `StateGraph`
+- **deepagents-python-quickstart** / **deepagents-typescript-quickstart** — research agent with **provider-native web search** (no Tavily)
 
 ### Deep Agents
 - **deep-agents-core** - Agent architecture, harness setup, and SKILL.md format

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -11,10 +11,10 @@ This project uses skills that contain up-to-date patterns and working reference 
 - **langchain-dependencies** - Invoke before installing packages or when resolving version issues (Python + TypeScript)
 
 ### Local quickstarts
-Invoke when the user wants a minimal working local agent (new directory, stub tool, provider API key only):
-- **langchain-python-quickstart** / **langchain-typescript-quickstart**
-- **langgraph-python-quickstart** / **langgraph-typescript-quickstart**
-- **deepagents-python-quickstart** / **deepagents-typescript-quickstart**
+Invoke when the user wants a minimal working local agent. Skills point at the official Mintlify quickstarts (fetch live docs); add provider/model prompt + provider-key-only setup:
+- **langchain-python-quickstart** / **langchain-typescript-quickstart** (weather)
+- **langgraph-python-quickstart** / **langgraph-typescript-quickstart** (math)
+- **deepagents-python-quickstart** / **deepagents-typescript-quickstart** (research; provider web search, not Tavily)
 
 ### LangChain Skills
 - **langchain-fundamentals** - Invoke for create_agent, @tool decorator, middleware patterns

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -10,6 +10,12 @@ This project uses skills that contain up-to-date patterns and working reference 
 - **ecosystem-primer** - Invoke FIRST for any LangChain/LangGraph/Deep Agents project: framework selection, env setup, and which skill to load next
 - **langchain-dependencies** - Invoke before installing packages or when resolving version issues (Python + TypeScript)
 
+### Local quickstarts
+Invoke when the user wants a minimal working local agent (new directory, stub tool, provider API key only):
+- **langchain-python-quickstart** / **langchain-typescript-quickstart**
+- **langgraph-python-quickstart** / **langgraph-typescript-quickstart**
+- **deepagents-python-quickstart** / **deepagents-typescript-quickstart**
+
 ### LangChain Skills
 - **langchain-fundamentals** - Invoke for create_agent, @tool decorator, middleware patterns
 - **langchain-rag** - Invoke for RAG pipelines, vector stores, embeddings

--- a/config/skills/deepagents-python-quickstart/SKILL.md
+++ b/config/skills/deepagents-python-quickstart/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: deepagents-python-quickstart
+description: "Scaffold a minimal local Deep Agent in Python with create_deep_agent and provider-native web search (no Tavily). Use when the user wants to quickly build or try a Deep Agent locally."
+---
+
+# Deep Agents Python quickstart
+
+Get a working local Deep Agent that can research via **provider-side web search** (only a provider API key — no Tavily). Inspired by https://docs.langchain.com/oss/python/deepagents/overview and the research quickstart shape, without a second search vendor.
+
+## Rules
+
+- Ask which **provider and model** to use (showcase model-agnosticism). Default to `anthropic:claude-sonnet-5` if they don't care.
+- Prefer Anthropic, OpenAI, or Google — each has a built-in web search tool. Only secret: that provider's API key. No Tavily, LangSmith, or other keys.
+- Create a **new** directory (e.g. `deep-agent/`) and do all work there. Do not add files to the user's currently open project.
+- Prefer the user edits `.env` themselves — do not ask them to paste keys into chat.
+- Stop after a successful run. Briefly point to `deep-agents-core` / docs for next steps.
+
+## Steps
+
+1. **Ask** for provider/model. Emphasize Deep Agents work with any LangChain chat model. Suggested prompt:
+
+   > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google_genai:gemini-3.5-flash`. Default if you're unsure: **`anthropic:claude-sonnet-5`**.  
+   > We'll enable that provider's built-in web search (no separate search API key).
+
+   Do not proceed until they answer or accept the default. Use their choice as `<MODEL>` below.
+
+2. **Scaffold**
+   ```bash
+   mkdir deep-agent && cd deep-agent
+   uv init
+   uv add deepagents python-dotenv
+   ```
+   Install the matching provider package for `<MODEL>` (e.g. `langchain-openai`, `langchain-anthropic`, `langchain-google-genai`).
+
+3. **Pick the provider web-search tool** for their model (look up current docs if the type string has changed):
+
+   | Provider | Tool dict to pass in `tools=[...]` |
+   |----------|-------------------------------------|
+   | Anthropic | `{"type": "web_search_20260209", "name": "web_search", "max_uses": 5}` |
+   | OpenAI | `{"type": "web_search"}` |
+   | Google | `{"google_search": {}}` |
+
+   If they chose another provider, check that provider's LangChain chat docs for a built-in search tool; if none exists, tell them and fall back to Anthropic/OpenAI/Google.
+
+4. **Write** `main.py` (swap `<MODEL>` and `<PROVIDER_SEARCH_TOOL>`):
+
+   ```python
+   from dotenv import load_dotenv
+   load_dotenv()
+
+   from deepagents import create_deep_agent
+
+   research_instructions = """You are an expert researcher. Conduct brief research and write a clear, polished answer.
+   Use web search to gather current information when needed.
+   """
+
+   agent = create_deep_agent(
+       model="<MODEL>",
+       tools=[<PROVIDER_SEARCH_TOOL>],
+       system_prompt=research_instructions,
+   )
+
+   result = agent.invoke(
+       {"messages": [{"role": "user", "content": "What is LangGraph?"}]}
+   )
+   print(result["messages"][-1].content)
+   ```
+
+   Example for Anthropic default:
+
+   ```python
+   tools=[{"type": "web_search_20260209", "name": "web_search", "max_uses": 5}],
+   ```
+
+5. **Env**
+   - Create `.env` with a single empty placeholder for the key their provider needs.
+   - Ensure `.env` is in `.gitignore`.
+   - Ask them to fill it in, then wait.
+
+6. **Run** `uv run python main.py`. Show the output. If it fails: missing provider package, blank key, bad model id, or unsupported search tool type — fix and retry (re-check the provider's built-in tools docs).
+
+7. **Done** — summarize files created. Suggest `deep-agents-core`, `deep-agents-memory`, `deep-agents-orchestration`, or Managed Deep Agents for deploy. Do not set up LangSmith tracing unless they ask.

--- a/config/skills/deepagents-python-quickstart/SKILL.md
+++ b/config/skills/deepagents-python-quickstart/SKILL.md
@@ -1,82 +1,37 @@
 ---
 name: deepagents-python-quickstart
-description: "Scaffold a minimal local Deep Agent in Python with create_deep_agent and provider-native web search (no Tavily). Use when the user wants to quickly build or try a Deep Agent locally."
+description: "Scaffold a minimal local Deep Agent in Python by following the official quickstart, using provider-native web search instead of Tavily. Use when the user wants to quickly build or try a Deep Agent locally."
 ---
 
 # Deep Agents Python quickstart
 
-Get a working local Deep Agent that can research via **provider-side web search** (only a provider API key — no Tavily). Inspired by https://docs.langchain.com/oss/python/deepagents/overview and the research quickstart shape, without a second search vendor.
+Follow the live docs — do not invent an alternate API from memory:
 
-## Rules
+**https://docs.langchain.com/oss/python/deepagents/quickstart**
 
-- Ask which **provider and model** to use (showcase model-agnosticism). Default to `anthropic:claude-sonnet-5` if they don't care.
-- Prefer Anthropic, OpenAI, or Google — each has a built-in web search tool. Only secret: that provider's API key. No Tavily, LangSmith, or other keys.
-- Create a **new** directory (e.g. `deep-agent/`) and do all work there. Do not add files to the user's currently open project.
-- Prefer the user edits `.env` themselves — do not ask them to paste keys into chat.
-- Stop after a successful run. Briefly point to `deep-agents-core` / docs for next steps.
+Fetch that page (Docs MCP or HTTP) and implement the research-agent shape it shows (`create_deep_agent`, research system prompt, invoke with a research question like “What is LangGraph?”).
 
-## Steps
+## Local setup constraints
 
-1. **Ask** for provider/model. Emphasize Deep Agents work with any LangChain chat model. Suggested prompt:
+Apply these on top of the quickstart (they keep setup minimal and model-agnostic):
+
+1. **Ask** which provider/model to use. Showcase that Deep Agents are model-agnostic. Suggested prompt:
 
    > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google_genai:gemini-3.5-flash`. Default if you're unsure: **`anthropic:claude-sonnet-5`**.  
-   > We'll enable that provider's built-in web search (no separate search API key).
+   > We'll use that provider's built-in web search (no separate search API key).
 
-   Do not proceed until they answer or accept the default. Use their choice as `<MODEL>` below.
+2. Create a **new** directory (e.g. `deep-agent/`) and do all work there — do not pollute the open project.
 
-2. **Scaffold**
-   ```bash
-   mkdir deep-agent && cd deep-agent
-   uv init
-   uv add deepagents python-dotenv
-   ```
-   Install the matching provider package for `<MODEL>` (e.g. `langchain-openai`, `langchain-anthropic`, `langchain-google-genai`).
+3. **Do not use Tavily** (or any second search vendor). Replace the quickstart's `internet_search` / Tavily tool with the chosen provider's built-in web search. Look up the current tool shape on that provider's LangChain chat docs (examples as of writing — re-check if needed):
 
-3. **Pick the provider web-search tool** for their model (look up current docs if the type string has changed):
-
-   | Provider | Tool dict to pass in `tools=[...]` |
-   |----------|-------------------------------------|
+   | Provider | Built-in search tool |
+   |----------|----------------------|
    | Anthropic | `{"type": "web_search_20260209", "name": "web_search", "max_uses": 5}` |
    | OpenAI | `{"type": "web_search"}` |
    | Google | `{"google_search": {}}` |
 
-   If they chose another provider, check that provider's LangChain chat docs for a built-in search tool; if none exists, tell them and fall back to Anthropic/OpenAI/Google.
+   Prefer Anthropic / OpenAI / Google so provider search is available. Only secret: that provider's API key in `.env` (gitignored). Skip LangSmith tracing unless they ask.
 
-4. **Write** `main.py` (swap `<MODEL>` and `<PROVIDER_SEARCH_TOOL>`):
+4. Install `deepagents` (+ `python-dotenv`) and the provider package for their model — not `tavily-python`.
 
-   ```python
-   from dotenv import load_dotenv
-   load_dotenv()
-
-   from deepagents import create_deep_agent
-
-   research_instructions = """You are an expert researcher. Conduct brief research and write a clear, polished answer.
-   Use web search to gather current information when needed.
-   """
-
-   agent = create_deep_agent(
-       model="<MODEL>",
-       tools=[<PROVIDER_SEARCH_TOOL>],
-       system_prompt=research_instructions,
-   )
-
-   result = agent.invoke(
-       {"messages": [{"role": "user", "content": "What is LangGraph?"}]}
-   )
-   print(result["messages"][-1].content)
-   ```
-
-   Example for Anthropic default:
-
-   ```python
-   tools=[{"type": "web_search_20260209", "name": "web_search", "max_uses": 5}],
-   ```
-
-5. **Env**
-   - Create `.env` with a single empty placeholder for the key their provider needs.
-   - Ensure `.env` is in `.gitignore`.
-   - Ask them to fill it in, then wait.
-
-6. **Run** `uv run python main.py`. Show the output. If it fails: missing provider package, blank key, bad model id, or unsupported search tool type — fix and retry (re-check the provider's built-in tools docs).
-
-7. **Done** — summarize files created. Suggest `deep-agents-core`, `deep-agents-memory`, `deep-agents-orchestration`, or Managed Deep Agents for deploy. Do not set up LangSmith tracing unless they ask.
+5. Run the research example, show output, then stop. Point to `deep-agents-core` / customization / Managed Deep Agents for next steps.

--- a/config/skills/deepagents-typescript-quickstart/SKILL.md
+++ b/config/skills/deepagents-typescript-quickstart/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: deepagents-typescript-quickstart
+description: "Scaffold a minimal local Deep Agent in TypeScript with createDeepAgent and provider-native web search (no Tavily). Use when the user wants to quickly build or try a Deep Agent locally."
+---
+
+# Deep Agents TypeScript quickstart
+
+Get a working local Deep Agent that can research via **provider-side web search** (only a provider API key — no Tavily). Inspired by https://docs.langchain.com/oss/javascript/deepagents/overview and the research quickstart shape, without a second search vendor.
+
+## Rules
+
+- Ask which **provider and model** to use (showcase model-agnosticism). Default to `anthropic:claude-sonnet-5` if they don't care.
+- Prefer Anthropic, OpenAI, or Google — each has a built-in web search tool. Only secret: that provider's API key. No Tavily, LangSmith, or other keys.
+- Create a **new** directory (e.g. `deep-agent/`) and do all work there. Do not add files to the user's currently open project.
+- Prefer the user edits `.env` themselves — do not ask them to paste keys into chat.
+- Requires Node 22+. Stop after a successful run. Briefly point to `deep-agents-core` / docs for next steps.
+
+## Steps
+
+1. **Ask** for provider/model. Emphasize Deep Agents work with any LangChain chat model. Suggested prompt:
+
+   > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google-genai:gemini-3.5-flash`. Default if you're unsure: **`anthropic:claude-sonnet-5`**.  
+   > We'll enable that provider's built-in web search (no separate search API key).
+
+   Do not proceed until they answer or accept the default. Use their choice as `<MODEL>` below.
+
+2. **Scaffold**
+   ```bash
+   mkdir deep-agent && cd deep-agent
+   npm init -y
+   npm install deepagents langchain @langchain/core zod dotenv
+   ```
+   Install the matching provider package for `<MODEL>` (e.g. `@langchain/openai`, `@langchain/anthropic`, `@langchain/google-genai`).
+   Add `"type": "module"` to `package.json` if missing.
+
+3. **Pick the provider web-search tool** for their model (look up current docs / package exports if names differ):
+
+   | Provider | How to get the tool |
+   |----------|---------------------|
+   | Anthropic | From `@langchain/anthropic`: `tools.webSearch_20250305()` (or newer `webSearch_*` export if present) — or pass `{ type: "web_search_20250305", name: "web_search" }` |
+   | OpenAI | `{ type: "web_search" }` |
+   | Google | `{ google_search: {} }` (confirm against current `@langchain/google-genai` docs) |
+
+   If they chose another provider, check that provider's LangChain chat docs for a built-in search tool; if none exists, tell them and fall back to Anthropic/OpenAI/Google.
+
+4. **Write** `main.ts` (swap `<MODEL>` and search tool). Prefer `await createDeepAgent` if the installed API is async:
+
+   ```typescript
+   import "dotenv/config";
+   import { createDeepAgent } from "deepagents";
+
+   const researchInstructions = `You are an expert researcher. Conduct brief research and write a clear, polished answer.
+   Use web search to gather current information when needed.`;
+
+   const agent = await createDeepAgent({
+     model: "<MODEL>",
+     tools: [<PROVIDER_SEARCH_TOOL>],
+     systemPrompt: researchInstructions,
+   });
+
+   const result = await agent.invoke({
+     messages: [{ role: "user", content: "What is LangGraph?" }],
+   });
+   console.log(result.messages[result.messages.length - 1].content);
+   ```
+
+   Example for Anthropic default (adjust import to match installed `@langchain/anthropic`):
+
+   ```typescript
+   import { tools as anthropicTools } from "@langchain/anthropic";
+   // tools: [anthropicTools.webSearch_20250305()]
+   ```
+
+5. **Env**
+   - Create `.env` with a single empty placeholder for the key their provider needs.
+   - Ensure `.env` is in `.gitignore`.
+   - Ask them to fill it in, then wait.
+
+6. **Run** with `npx tsx main.ts` (install `tsx` if needed). Show the output. If it fails: missing provider package, blank key, bad model id, or unsupported search tool — fix and retry.
+
+7. **Done** — summarize files created. Suggest `deep-agents-core`, `deep-agents-memory`, `deep-agents-orchestration`, or Managed Deep Agents for deploy. Do not set up LangSmith tracing unless they ask.

--- a/config/skills/deepagents-typescript-quickstart/SKILL.md
+++ b/config/skills/deepagents-typescript-quickstart/SKILL.md
@@ -1,81 +1,37 @@
 ---
 name: deepagents-typescript-quickstart
-description: "Scaffold a minimal local Deep Agent in TypeScript with createDeepAgent and provider-native web search (no Tavily). Use when the user wants to quickly build or try a Deep Agent locally."
+description: "Scaffold a minimal local Deep Agent in TypeScript by following the official quickstart, using provider-native web search instead of Tavily. Use when the user wants to quickly build or try a Deep Agent locally."
 ---
 
 # Deep Agents TypeScript quickstart
 
-Get a working local Deep Agent that can research via **provider-side web search** (only a provider API key — no Tavily). Inspired by https://docs.langchain.com/oss/javascript/deepagents/overview and the research quickstart shape, without a second search vendor.
+Follow the live docs — do not invent an alternate API from memory:
 
-## Rules
+**https://docs.langchain.com/oss/javascript/deepagents/quickstart**
 
-- Ask which **provider and model** to use (showcase model-agnosticism). Default to `anthropic:claude-sonnet-5` if they don't care.
-- Prefer Anthropic, OpenAI, or Google — each has a built-in web search tool. Only secret: that provider's API key. No Tavily, LangSmith, or other keys.
-- Create a **new** directory (e.g. `deep-agent/`) and do all work there. Do not add files to the user's currently open project.
-- Prefer the user edits `.env` themselves — do not ask them to paste keys into chat.
-- Requires Node 22+. Stop after a successful run. Briefly point to `deep-agents-core` / docs for next steps.
+Fetch that page (Docs MCP or HTTP) and implement the research-agent shape it shows (`createDeepAgent`, research system prompt, invoke with a research question like “What is LangGraph?”). Requires Node 22+.
 
-## Steps
+## Local setup constraints
 
-1. **Ask** for provider/model. Emphasize Deep Agents work with any LangChain chat model. Suggested prompt:
+Apply these on top of the quickstart (they keep setup minimal and model-agnostic):
+
+1. **Ask** which provider/model to use. Showcase that Deep Agents are model-agnostic. Suggested prompt:
 
    > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google-genai:gemini-3.5-flash`. Default if you're unsure: **`anthropic:claude-sonnet-5`**.  
-   > We'll enable that provider's built-in web search (no separate search API key).
+   > We'll use that provider's built-in web search (no separate search API key).
 
-   Do not proceed until they answer or accept the default. Use their choice as `<MODEL>` below.
+2. Create a **new** directory (e.g. `deep-agent/`) and do all work there — do not pollute the open project.
 
-2. **Scaffold**
-   ```bash
-   mkdir deep-agent && cd deep-agent
-   npm init -y
-   npm install deepagents langchain @langchain/core zod dotenv
-   ```
-   Install the matching provider package for `<MODEL>` (e.g. `@langchain/openai`, `@langchain/anthropic`, `@langchain/google-genai`).
-   Add `"type": "module"` to `package.json` if missing.
+3. **Do not use Tavily** (or `@langchain/tavily`). Replace the quickstart's search tool with the chosen provider's built-in web search. Look up the current export/tool shape on that provider's LangChain docs (examples as of writing — re-check if needed):
 
-3. **Pick the provider web-search tool** for their model (look up current docs / package exports if names differ):
-
-   | Provider | How to get the tool |
-   |----------|---------------------|
-   | Anthropic | From `@langchain/anthropic`: `tools.webSearch_20250305()` (or newer `webSearch_*` export if present) — or pass `{ type: "web_search_20250305", name: "web_search" }` |
+   | Provider | Built-in search tool |
+   |----------|----------------------|
+   | Anthropic | `@langchain/anthropic` `tools.webSearch_*()` (or equivalent dict) |
    | OpenAI | `{ type: "web_search" }` |
-   | Google | `{ google_search: {} }` (confirm against current `@langchain/google-genai` docs) |
+   | Google | `{ google_search: {} }` |
 
-   If they chose another provider, check that provider's LangChain chat docs for a built-in search tool; if none exists, tell them and fall back to Anthropic/OpenAI/Google.
+   Prefer Anthropic / OpenAI / Google so provider search is available. Only secret: that provider's API key in `.env` (gitignored). Skip LangSmith tracing unless they ask.
 
-4. **Write** `main.ts` (swap `<MODEL>` and search tool). Prefer `await createDeepAgent` if the installed API is async:
+4. Install packages from the quickstart **minus** Tavily; add the provider package for their model.
 
-   ```typescript
-   import "dotenv/config";
-   import { createDeepAgent } from "deepagents";
-
-   const researchInstructions = `You are an expert researcher. Conduct brief research and write a clear, polished answer.
-   Use web search to gather current information when needed.`;
-
-   const agent = await createDeepAgent({
-     model: "<MODEL>",
-     tools: [<PROVIDER_SEARCH_TOOL>],
-     systemPrompt: researchInstructions,
-   });
-
-   const result = await agent.invoke({
-     messages: [{ role: "user", content: "What is LangGraph?" }],
-   });
-   console.log(result.messages[result.messages.length - 1].content);
-   ```
-
-   Example for Anthropic default (adjust import to match installed `@langchain/anthropic`):
-
-   ```typescript
-   import { tools as anthropicTools } from "@langchain/anthropic";
-   // tools: [anthropicTools.webSearch_20250305()]
-   ```
-
-5. **Env**
-   - Create `.env` with a single empty placeholder for the key their provider needs.
-   - Ensure `.env` is in `.gitignore`.
-   - Ask them to fill it in, then wait.
-
-6. **Run** with `npx tsx main.ts` (install `tsx` if needed). Show the output. If it fails: missing provider package, blank key, bad model id, or unsupported search tool — fix and retry.
-
-7. **Done** — summarize files created. Suggest `deep-agents-core`, `deep-agents-memory`, `deep-agents-orchestration`, or Managed Deep Agents for deploy. Do not set up LangSmith tracing unless they ask.
+5. Run the research example, show output, then stop. Point to `deep-agents-core` / customization / Managed Deep Agents for next steps.

--- a/config/skills/ecosystem-primer/SKILL.md
+++ b/config/skills/ecosystem-primer/SKILL.md
@@ -164,7 +164,13 @@ rg -il "checkpointer" /oss/python/langgraph/ # search by keyword
 
 ## Step 4 — Load the Right Skill Next
 
-Now load the skill below that matches your layer from Step 1. This is required — the layer-specific skill carries the current API; the primer alone does not.
+If the user only wants a minimal local working agent (new project, stub tool, provider key), load the matching quickstart first:
+
+- LangChain → `langchain-python-quickstart` or `langchain-typescript-quickstart`
+- LangGraph → `langgraph-python-quickstart` or `langgraph-typescript-quickstart`
+- Deep Agents → `deepagents-python-quickstart` or `deepagents-typescript-quickstart`
+
+Otherwise load the skill below that matches your layer from Step 1. This is required — the layer-specific skill carries the current API; the primer alone does not.
 
 <next-skills>
 

--- a/config/skills/langchain-python-quickstart/SKILL.md
+++ b/config/skills/langchain-python-quickstart/SKILL.md
@@ -1,65 +1,30 @@
 ---
 name: langchain-python-quickstart
-description: "Scaffold a minimal local LangChain agent in Python with create_agent, one stub tool, and a provider API key. Use when the user wants to quickly build or try a LangChain agent locally."
+description: "Scaffold a minimal local LangChain agent in Python by following the official quickstart. Use when the user wants to quickly build or try a LangChain agent locally."
 ---
 
 # LangChain Python quickstart
 
-Get a working local LangChain agent with minimal setup. Mirror the official quickstart: https://docs.langchain.com/oss/python/langchain/quickstart
+Follow the live docs — do not invent an alternate API from memory:
 
-## Rules
+**https://docs.langchain.com/oss/python/langchain/quickstart**
 
-- Ask which **provider and model** to use (showcase model-agnosticism). Default to `anthropic:claude-sonnet-5` if they don't care.
-- Only secret: the provider API key. No Tavily, LangSmith, or other keys.
-- Create a **new** directory (e.g. `langchain-agent/`) and do all work there. Do not add files to the user's currently open project.
-- Use a stub weather tool (no network). Prefer the user edits `.env` themselves — do not ask them to paste keys into chat.
-- Stop after a successful run. Briefly point to `langchain-fundamentals` / docs for next steps.
+Fetch that page (Docs MCP or HTTP) and implement what it shows (weather agent + `create_agent`).
 
-## Steps
+## Local setup constraints
 
-1. **Ask** for provider/model. Emphasize LangChain works with any supported chat model — not locked to one vendor. Suggested prompt:
+Apply these on top of the quickstart (they keep setup minimal and model-agnostic):
 
-   > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google_genai:gemini-2.5-flash-lite`, or another [supported provider](https://docs.langchain.com/oss/python/integrations/chat). Default if you're unsure: **`anthropic:claude-sonnet-5`**.
+1. **Ask** which provider/model to use. Showcase that LangChain is model-agnostic. Suggested prompt:
 
-   Do not proceed until they answer or accept the default. Use their choice as `<MODEL>` below.
+   > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google_genai:gemini-2.5-flash-lite`. Default if you're unsure: **`anthropic:claude-sonnet-5`**.
 
-2. **Scaffold**
-   ```bash
-   mkdir langchain-agent && cd langchain-agent
-   uv init
-   uv add langchain python-dotenv
-   ```
-   Install the matching provider package for `<MODEL>` (e.g. `langchain-openai`, `langchain-anthropic`, `langchain-google-genai`).
+   Swap the quickstart's model string for their choice (or the default).
 
-3. **Write** `main.py`:
+2. Create a **new** directory (e.g. `langchain-agent/`) and do all work there — do not pollute the open project.
 
-   ```python
-   from dotenv import load_dotenv
-   load_dotenv()
+3. Only secret: the provider API key in `.env` (gitignored). No LangSmith / Tavily unless they ask. Prefer they edit `.env` themselves — don't paste keys into chat.
 
-   from langchain.agents import create_agent
+4. Install the provider package needed for their model if the quickstart's base install isn't enough.
 
-   def get_weather(city: str) -> str:
-       """Get weather for a given city."""
-       return f"It's always sunny in {city}!"
-
-   agent = create_agent(
-       model="<MODEL>",
-       tools=[get_weather],
-       system_prompt="You are a helpful assistant",
-   )
-
-   result = agent.invoke(
-       {"messages": [{"role": "user", "content": "What's the weather in San Francisco?"}]}
-   )
-   print(result["messages"][-1].content)
-   ```
-
-4. **Env**
-   - Create `.env` with a single empty placeholder for the key their provider needs (e.g. `ANTHROPIC_API_KEY=`, `OPENAI_API_KEY=`, `GOOGLE_API_KEY=`).
-   - Ensure `.env` is in `.gitignore`.
-   - Ask them to fill it in, then wait.
-
-5. **Run** `uv run python main.py`. Show the output. If it fails: missing provider package, blank key, or bad model id — fix and retry.
-
-6. **Done** — summarize files created. Suggest customizing tools / `system_prompt`, then `langchain-fundamentals` for middleware, memory, and structured output.
+5. Run the example, show output, then stop. Point to `langchain-fundamentals` for next steps.

--- a/config/skills/langchain-python-quickstart/SKILL.md
+++ b/config/skills/langchain-python-quickstart/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: langchain-python-quickstart
+description: "Scaffold a minimal local LangChain agent in Python with create_agent, one stub tool, and a provider API key. Use when the user wants to quickly build or try a LangChain agent locally."
+---
+
+# LangChain Python quickstart
+
+Get a working local LangChain agent with minimal setup. Mirror the official quickstart: https://docs.langchain.com/oss/python/langchain/quickstart
+
+## Rules
+
+- Ask which **provider and model** to use (showcase model-agnosticism). Default to `anthropic:claude-sonnet-5` if they don't care.
+- Only secret: the provider API key. No Tavily, LangSmith, or other keys.
+- Create a **new** directory (e.g. `langchain-agent/`) and do all work there. Do not add files to the user's currently open project.
+- Use a stub weather tool (no network). Prefer the user edits `.env` themselves — do not ask them to paste keys into chat.
+- Stop after a successful run. Briefly point to `langchain-fundamentals` / docs for next steps.
+
+## Steps
+
+1. **Ask** for provider/model. Emphasize LangChain works with any supported chat model — not locked to one vendor. Suggested prompt:
+
+   > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google_genai:gemini-2.5-flash-lite`, or another [supported provider](https://docs.langchain.com/oss/python/integrations/chat). Default if you're unsure: **`anthropic:claude-sonnet-5`**.
+
+   Do not proceed until they answer or accept the default. Use their choice as `<MODEL>` below.
+
+2. **Scaffold**
+   ```bash
+   mkdir langchain-agent && cd langchain-agent
+   uv init
+   uv add langchain python-dotenv
+   ```
+   Install the matching provider package for `<MODEL>` (e.g. `langchain-openai`, `langchain-anthropic`, `langchain-google-genai`).
+
+3. **Write** `main.py`:
+
+   ```python
+   from dotenv import load_dotenv
+   load_dotenv()
+
+   from langchain.agents import create_agent
+
+   def get_weather(city: str) -> str:
+       """Get weather for a given city."""
+       return f"It's always sunny in {city}!"
+
+   agent = create_agent(
+       model="<MODEL>",
+       tools=[get_weather],
+       system_prompt="You are a helpful assistant",
+   )
+
+   result = agent.invoke(
+       {"messages": [{"role": "user", "content": "What's the weather in San Francisco?"}]}
+   )
+   print(result["messages"][-1].content)
+   ```
+
+4. **Env**
+   - Create `.env` with a single empty placeholder for the key their provider needs (e.g. `ANTHROPIC_API_KEY=`, `OPENAI_API_KEY=`, `GOOGLE_API_KEY=`).
+   - Ensure `.env` is in `.gitignore`.
+   - Ask them to fill it in, then wait.
+
+5. **Run** `uv run python main.py`. Show the output. If it fails: missing provider package, blank key, or bad model id — fix and retry.
+
+6. **Done** — summarize files created. Suggest customizing tools / `system_prompt`, then `langchain-fundamentals` for middleware, memory, and structured output.

--- a/config/skills/langchain-typescript-quickstart/SKILL.md
+++ b/config/skills/langchain-typescript-quickstart/SKILL.md
@@ -1,70 +1,30 @@
 ---
 name: langchain-typescript-quickstart
-description: "Scaffold a minimal local LangChain agent in TypeScript with createAgent, one stub tool, and a provider API key. Use when the user wants to quickly build or try a LangChain agent locally."
+description: "Scaffold a minimal local LangChain agent in TypeScript by following the official quickstart. Use when the user wants to quickly build or try a LangChain agent locally."
 ---
 
 # LangChain TypeScript quickstart
 
-Get a working local LangChain agent with minimal setup. Mirror the official quickstart: https://docs.langchain.com/oss/javascript/langchain/quickstart
+Follow the live docs — do not invent an alternate API from memory:
 
-## Rules
+**https://docs.langchain.com/oss/javascript/langchain/quickstart**
 
-- Ask which **provider and model** to use (showcase model-agnosticism). Default to `anthropic:claude-sonnet-5` if they don't care.
-- Only secret: the provider API key. No Tavily, LangSmith, or other keys.
-- Create a **new** directory (e.g. `langchain-agent/`) and do all work there. Do not add files to the user's currently open project.
-- Use a stub weather tool (no network). Prefer the user edits `.env` themselves — do not ask them to paste keys into chat.
-- Requires Node 22+. Stop after a successful run. Briefly point to `langchain-fundamentals` / docs for next steps.
+Fetch that page (Docs MCP or HTTP) and implement what it shows (weather agent + `createAgent`). Requires Node 22+.
 
-## Steps
+## Local setup constraints
 
-1. **Ask** for provider/model. Emphasize LangChain works with any supported chat model — not locked to one vendor. Suggested prompt:
+Apply these on top of the quickstart (they keep setup minimal and model-agnostic):
 
-   > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google-genai:gemini-2.5-flash-lite`, or another [supported provider](https://docs.langchain.com/oss/javascript/integrations/chat). Default if you're unsure: **`anthropic:claude-sonnet-5`**.
+1. **Ask** which provider/model to use. Showcase that LangChain is model-agnostic. Suggested prompt:
 
-   Do not proceed until they answer or accept the default. Use their choice as `<MODEL>` below.
+   > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google-genai:gemini-2.5-flash-lite`. Default if you're unsure: **`anthropic:claude-sonnet-5`**.
 
-2. **Scaffold**
-   ```bash
-   mkdir langchain-agent && cd langchain-agent
-   npm init -y
-   npm install langchain @langchain/core zod dotenv
-   ```
-   Install the matching provider package for `<MODEL>` (e.g. `@langchain/openai`, `@langchain/anthropic`, `@langchain/google-genai`).
-   Add `"type": "module"` to `package.json` if missing.
+   Swap the quickstart's model string for their choice (or the default).
 
-3. **Write** `main.ts`:
+2. Create a **new** directory (e.g. `langchain-agent/`) and do all work there — do not pollute the open project.
 
-   ```typescript
-   import "dotenv/config";
-   import { createAgent, tool } from "langchain";
-   import * as z from "zod";
+3. Only secret: the provider API key in `.env` (gitignored). No LangSmith / Tavily unless they ask. Prefer they edit `.env` themselves — don't paste keys into chat.
 
-   const getWeather = tool(
-     ({ city }) => `It's always sunny in ${city}!`,
-     {
-       name: "get_weather",
-       description: "Get weather for a given city",
-       schema: z.object({ city: z.string() }),
-     }
-   );
+4. Install the provider package needed for their model if the quickstart's base install isn't enough.
 
-   const agent = createAgent({
-     model: "<MODEL>",
-     tools: [getWeather],
-     systemPrompt: "You are a helpful assistant",
-   });
-
-   const result = await agent.invoke({
-     messages: [{ role: "user", content: "What's the weather in San Francisco?" }],
-   });
-   console.log(result.messages[result.messages.length - 1].content);
-   ```
-
-4. **Env**
-   - Create `.env` with a single empty placeholder for the key their provider needs (e.g. `ANTHROPIC_API_KEY=`, `OPENAI_API_KEY=`, `GOOGLE_API_KEY=`).
-   - Ensure `.env` is in `.gitignore`.
-   - Ask them to fill it in, then wait.
-
-5. **Run** with `npx tsx main.ts` (install `tsx` if needed). Show the output. If it fails: missing provider package, blank key, or bad model id — fix and retry.
-
-6. **Done** — summarize files created. Suggest customizing tools / `systemPrompt`, then `langchain-fundamentals` for middleware, memory, and structured output.
+5. Run the example, show output, then stop. Point to `langchain-fundamentals` for next steps.

--- a/config/skills/langchain-typescript-quickstart/SKILL.md
+++ b/config/skills/langchain-typescript-quickstart/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: langchain-typescript-quickstart
+description: "Scaffold a minimal local LangChain agent in TypeScript with createAgent, one stub tool, and a provider API key. Use when the user wants to quickly build or try a LangChain agent locally."
+---
+
+# LangChain TypeScript quickstart
+
+Get a working local LangChain agent with minimal setup. Mirror the official quickstart: https://docs.langchain.com/oss/javascript/langchain/quickstart
+
+## Rules
+
+- Ask which **provider and model** to use (showcase model-agnosticism). Default to `anthropic:claude-sonnet-5` if they don't care.
+- Only secret: the provider API key. No Tavily, LangSmith, or other keys.
+- Create a **new** directory (e.g. `langchain-agent/`) and do all work there. Do not add files to the user's currently open project.
+- Use a stub weather tool (no network). Prefer the user edits `.env` themselves — do not ask them to paste keys into chat.
+- Requires Node 22+. Stop after a successful run. Briefly point to `langchain-fundamentals` / docs for next steps.
+
+## Steps
+
+1. **Ask** for provider/model. Emphasize LangChain works with any supported chat model — not locked to one vendor. Suggested prompt:
+
+   > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google-genai:gemini-2.5-flash-lite`, or another [supported provider](https://docs.langchain.com/oss/javascript/integrations/chat). Default if you're unsure: **`anthropic:claude-sonnet-5`**.
+
+   Do not proceed until they answer or accept the default. Use their choice as `<MODEL>` below.
+
+2. **Scaffold**
+   ```bash
+   mkdir langchain-agent && cd langchain-agent
+   npm init -y
+   npm install langchain @langchain/core zod dotenv
+   ```
+   Install the matching provider package for `<MODEL>` (e.g. `@langchain/openai`, `@langchain/anthropic`, `@langchain/google-genai`).
+   Add `"type": "module"` to `package.json` if missing.
+
+3. **Write** `main.ts`:
+
+   ```typescript
+   import "dotenv/config";
+   import { createAgent, tool } from "langchain";
+   import * as z from "zod";
+
+   const getWeather = tool(
+     ({ city }) => `It's always sunny in ${city}!`,
+     {
+       name: "get_weather",
+       description: "Get weather for a given city",
+       schema: z.object({ city: z.string() }),
+     }
+   );
+
+   const agent = createAgent({
+     model: "<MODEL>",
+     tools: [getWeather],
+     systemPrompt: "You are a helpful assistant",
+   });
+
+   const result = await agent.invoke({
+     messages: [{ role: "user", content: "What's the weather in San Francisco?" }],
+   });
+   console.log(result.messages[result.messages.length - 1].content);
+   ```
+
+4. **Env**
+   - Create `.env` with a single empty placeholder for the key their provider needs (e.g. `ANTHROPIC_API_KEY=`, `OPENAI_API_KEY=`, `GOOGLE_API_KEY=`).
+   - Ensure `.env` is in `.gitignore`.
+   - Ask them to fill it in, then wait.
+
+5. **Run** with `npx tsx main.ts` (install `tsx` if needed). Show the output. If it fails: missing provider package, blank key, or bad model id — fix and retry.
+
+6. **Done** — summarize files created. Suggest customizing tools / `systemPrompt`, then `langchain-fundamentals` for middleware, memory, and structured output.

--- a/config/skills/langgraph-python-quickstart/SKILL.md
+++ b/config/skills/langgraph-python-quickstart/SKILL.md
@@ -1,111 +1,30 @@
 ---
 name: langgraph-python-quickstart
-description: "Scaffold a minimal local LangGraph agent in Python with StateGraph (tool-calling loop), one stub tool, and a provider API key. Use when the user wants to quickly build or try a LangGraph agent locally."
+description: "Scaffold a minimal local LangGraph agent in Python by following the official quickstart. Use when the user wants to quickly build or try a LangGraph agent locally."
 ---
 
 # LangGraph Python quickstart
 
-Get a working local LangGraph agent with minimal setup. Inspired by the Graph API quickstart: https://docs.langchain.com/oss/python/langgraph/quickstart  
-(Uses a stub weather tool instead of the docs calculator so setup stays provider-key-only.)
+Follow the live docs — do not invent an alternate API from memory:
 
-## Rules
+**https://docs.langchain.com/oss/python/langgraph/quickstart**
 
-- Ask which **provider and model** to use (showcase model-agnosticism). Default to `anthropic:claude-sonnet-5` if they don't care.
-- Only secret: the provider API key. No Tavily, LangSmith, or other keys.
-- Create a **new** directory (e.g. `langgraph-agent/`) and do all work there. Do not add files to the user's currently open project.
-- Use a stub weather tool (no network). Prefer the user edits `.env` themselves — do not ask them to paste keys into chat.
-- Use the Graph API (`StateGraph`), not deprecated `create_react_agent`. Skip graph visualization / IPython display.
-- Stop after a successful run. Briefly point to `langgraph-fundamentals` / docs for next steps.
+Fetch that page (Docs MCP or HTTP) and implement what it shows (calculator / math agent with the Graph API). Prefer the Graph API path over the Functional API unless the user asks otherwise. Skip IPython graph visualization.
 
-## Steps
+## Local setup constraints
 
-1. **Ask** for provider/model. Emphasize LangGraph works with any LangChain chat model — not locked to one vendor. Suggested prompt:
+Apply these on top of the quickstart (they keep setup minimal and model-agnostic):
 
-   > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google_genai:gemini-2.5-flash-lite`, or another [supported provider](https://docs.langchain.com/oss/python/integrations/chat). Default if you're unsure: **`anthropic:claude-sonnet-5`**.
+1. **Ask** which provider/model to use. Showcase that LangGraph works with any LangChain chat model. Suggested prompt:
 
-   Do not proceed until they answer or accept the default. Use their choice as `<MODEL>` below.
+   > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google_genai:gemini-2.5-flash-lite`. Default if you're unsure: **`anthropic:claude-sonnet-5`**.
 
-2. **Scaffold**
-   ```bash
-   mkdir langgraph-agent && cd langgraph-agent
-   uv init
-   uv add langgraph langchain python-dotenv
-   ```
-   Install the matching provider package for `<MODEL>` (e.g. `langchain-openai`, `langchain-anthropic`, `langchain-google-genai`).
+   The docs often hardcode Anthropic — replace with `init_chat_model("<MODEL>")` (or equivalent) using their choice. If using Claude Sonnet 5+, omit `temperature` / `top_p` / `top_k` (unsupported).
 
-3. **Write** `main.py` — minimal ReAct graph with one stub tool:
+2. Create a **new** directory (e.g. `langgraph-agent/`) and do all work there — do not pollute the open project.
 
-   ```python
-   from dotenv import load_dotenv
-   load_dotenv()
+3. Only secret: the provider API key in `.env` (gitignored). No LangSmith / Tavily unless they ask. Prefer they edit `.env` themselves — don't paste keys into chat.
 
-   import operator
-   from typing import Literal
+4. Install packages from the quickstart plus the provider package for their model.
 
-   from typing_extensions import Annotated, TypedDict
-
-   from langchain.chat_models import init_chat_model
-   from langchain.messages import AnyMessage, HumanMessage, SystemMessage, ToolMessage
-   from langchain.tools import tool
-   from langgraph.graph import END, START, StateGraph
-
-   model = init_chat_model("<MODEL>")
-   # If using Claude Sonnet 5+, omit temperature/top_p/top_k (unsupported).
-   # For older models you may pass temperature=0.
-
-   @tool
-   def get_weather(city: str) -> str:
-       """Get weather for a given city."""
-       return f"It's always sunny in {city}!"
-
-   tools = [get_weather]
-   tools_by_name = {t.name: t for t in tools}
-   model_with_tools = model.bind_tools(tools)
-
-   class MessagesState(TypedDict):
-       messages: Annotated[list[AnyMessage], operator.add]
-
-   def llm_call(state: MessagesState):
-       return {
-           "messages": [
-               model_with_tools.invoke(
-                   [SystemMessage(content="You are a helpful assistant.")]
-                   + state["messages"]
-               )
-           ]
-       }
-
-   def tool_node(state: MessagesState):
-       result = []
-       for tool_call in state["messages"][-1].tool_calls:
-           observation = tools_by_name[tool_call["name"]].invoke(tool_call["args"])
-           result.append(ToolMessage(content=str(observation), tool_call_id=tool_call["id"]))
-       return {"messages": result}
-
-   def should_continue(state: MessagesState) -> Literal["tool_node", END]:
-       return "tool_node" if state["messages"][-1].tool_calls else END
-
-   agent = (
-       StateGraph(MessagesState)
-       .add_node("llm_call", llm_call)
-       .add_node("tool_node", tool_node)
-       .add_edge(START, "llm_call")
-       .add_conditional_edges("llm_call", should_continue, ["tool_node", END])
-       .add_edge("tool_node", "llm_call")
-       .compile()
-   )
-
-   result = agent.invoke(
-       {"messages": [HumanMessage(content="What's the weather in San Francisco?")]}
-   )
-   print(result["messages"][-1].content)
-   ```
-
-4. **Env**
-   - Create `.env` with a single empty placeholder for the key their provider needs.
-   - Ensure `.env` is in `.gitignore`.
-   - Ask them to fill it in, then wait.
-
-5. **Run** `uv run python main.py`. Show the output. If it fails: missing provider package, blank key, or bad model id — fix and retry.
-
-6. **Done** — summarize files created. Suggest `langgraph-fundamentals` (state, edges, `Command`), `langgraph-persistence`, or `langgraph-human-in-the-loop` next. For a higher-level agent API, use LangChain `create_agent` instead.
+5. Run the example (e.g. “Add 3 and 4.”), show output, then stop. Point to `langgraph-fundamentals` for next steps. For a higher-level agent API, use LangChain `create_agent` instead.

--- a/config/skills/langgraph-python-quickstart/SKILL.md
+++ b/config/skills/langgraph-python-quickstart/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: langgraph-python-quickstart
+description: "Scaffold a minimal local LangGraph agent in Python with StateGraph (tool-calling loop), one stub tool, and a provider API key. Use when the user wants to quickly build or try a LangGraph agent locally."
+---
+
+# LangGraph Python quickstart
+
+Get a working local LangGraph agent with minimal setup. Inspired by the Graph API quickstart: https://docs.langchain.com/oss/python/langgraph/quickstart  
+(Uses a stub weather tool instead of the docs calculator so setup stays provider-key-only.)
+
+## Rules
+
+- Ask which **provider and model** to use (showcase model-agnosticism). Default to `anthropic:claude-sonnet-5` if they don't care.
+- Only secret: the provider API key. No Tavily, LangSmith, or other keys.
+- Create a **new** directory (e.g. `langgraph-agent/`) and do all work there. Do not add files to the user's currently open project.
+- Use a stub weather tool (no network). Prefer the user edits `.env` themselves — do not ask them to paste keys into chat.
+- Use the Graph API (`StateGraph`), not deprecated `create_react_agent`. Skip graph visualization / IPython display.
+- Stop after a successful run. Briefly point to `langgraph-fundamentals` / docs for next steps.
+
+## Steps
+
+1. **Ask** for provider/model. Emphasize LangGraph works with any LangChain chat model — not locked to one vendor. Suggested prompt:
+
+   > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google_genai:gemini-2.5-flash-lite`, or another [supported provider](https://docs.langchain.com/oss/python/integrations/chat). Default if you're unsure: **`anthropic:claude-sonnet-5`**.
+
+   Do not proceed until they answer or accept the default. Use their choice as `<MODEL>` below.
+
+2. **Scaffold**
+   ```bash
+   mkdir langgraph-agent && cd langgraph-agent
+   uv init
+   uv add langgraph langchain python-dotenv
+   ```
+   Install the matching provider package for `<MODEL>` (e.g. `langchain-openai`, `langchain-anthropic`, `langchain-google-genai`).
+
+3. **Write** `main.py` — minimal ReAct graph with one stub tool:
+
+   ```python
+   from dotenv import load_dotenv
+   load_dotenv()
+
+   import operator
+   from typing import Literal
+
+   from typing_extensions import Annotated, TypedDict
+
+   from langchain.chat_models import init_chat_model
+   from langchain.messages import AnyMessage, HumanMessage, SystemMessage, ToolMessage
+   from langchain.tools import tool
+   from langgraph.graph import END, START, StateGraph
+
+   model = init_chat_model("<MODEL>")
+   # If using Claude Sonnet 5+, omit temperature/top_p/top_k (unsupported).
+   # For older models you may pass temperature=0.
+
+   @tool
+   def get_weather(city: str) -> str:
+       """Get weather for a given city."""
+       return f"It's always sunny in {city}!"
+
+   tools = [get_weather]
+   tools_by_name = {t.name: t for t in tools}
+   model_with_tools = model.bind_tools(tools)
+
+   class MessagesState(TypedDict):
+       messages: Annotated[list[AnyMessage], operator.add]
+
+   def llm_call(state: MessagesState):
+       return {
+           "messages": [
+               model_with_tools.invoke(
+                   [SystemMessage(content="You are a helpful assistant.")]
+                   + state["messages"]
+               )
+           ]
+       }
+
+   def tool_node(state: MessagesState):
+       result = []
+       for tool_call in state["messages"][-1].tool_calls:
+           observation = tools_by_name[tool_call["name"]].invoke(tool_call["args"])
+           result.append(ToolMessage(content=str(observation), tool_call_id=tool_call["id"]))
+       return {"messages": result}
+
+   def should_continue(state: MessagesState) -> Literal["tool_node", END]:
+       return "tool_node" if state["messages"][-1].tool_calls else END
+
+   agent = (
+       StateGraph(MessagesState)
+       .add_node("llm_call", llm_call)
+       .add_node("tool_node", tool_node)
+       .add_edge(START, "llm_call")
+       .add_conditional_edges("llm_call", should_continue, ["tool_node", END])
+       .add_edge("tool_node", "llm_call")
+       .compile()
+   )
+
+   result = agent.invoke(
+       {"messages": [HumanMessage(content="What's the weather in San Francisco?")]}
+   )
+   print(result["messages"][-1].content)
+   ```
+
+4. **Env**
+   - Create `.env` with a single empty placeholder for the key their provider needs.
+   - Ensure `.env` is in `.gitignore`.
+   - Ask them to fill it in, then wait.
+
+5. **Run** `uv run python main.py`. Show the output. If it fails: missing provider package, blank key, or bad model id — fix and retry.
+
+6. **Done** — summarize files created. Suggest `langgraph-fundamentals` (state, edges, `Command`), `langgraph-persistence`, or `langgraph-human-in-the-loop` next. For a higher-level agent API, use LangChain `create_agent` instead.

--- a/config/skills/langgraph-typescript-quickstart/SKILL.md
+++ b/config/skills/langgraph-typescript-quickstart/SKILL.md
@@ -1,113 +1,30 @@
 ---
 name: langgraph-typescript-quickstart
-description: "Scaffold a minimal local LangGraph agent in TypeScript with StateGraph (tool-calling loop), one stub tool, and a provider API key. Use when the user wants to quickly build or try a LangGraph agent locally."
+description: "Scaffold a minimal local LangGraph agent in TypeScript by following the official quickstart. Use when the user wants to quickly build or try a LangGraph agent locally."
 ---
 
 # LangGraph TypeScript quickstart
 
-Get a working local LangGraph agent with minimal setup. Inspired by the Graph API quickstart: https://docs.langchain.com/oss/javascript/langgraph/quickstart  
-(Uses a stub weather tool instead of the docs calculator so setup stays provider-key-only.)
+Follow the live docs — do not invent an alternate API from memory:
 
-## Rules
+**https://docs.langchain.com/oss/javascript/langgraph/quickstart**
 
-- Ask which **provider and model** to use (showcase model-agnosticism). Default to `anthropic:claude-sonnet-5` if they don't care.
-- Only secret: the provider API key. No Tavily, LangSmith, or other keys.
-- Create a **new** directory (e.g. `langgraph-agent/`) and do all work there. Do not add files to the user's currently open project.
-- Use a stub weather tool (no network). Prefer the user edits `.env` themselves — do not ask them to paste keys into chat.
-- Use the Graph API (`StateGraph`), not deprecated prebuilt ReAct helpers. Skip graph visualization.
-- Stop after a successful run. Briefly point to `langgraph-fundamentals` / docs for next steps.
+Fetch that page (Docs MCP or HTTP) and implement what it shows (calculator / math agent with the Graph API). Prefer the Graph API path over the Functional API unless the user asks otherwise. Skip graph visualization.
 
-## Steps
+## Local setup constraints
 
-1. **Ask** for provider/model. Emphasize LangGraph works with any LangChain chat model — not locked to one vendor. Suggested prompt:
+Apply these on top of the quickstart (they keep setup minimal and model-agnostic):
 
-   > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google-genai:gemini-2.5-flash-lite`, or another [supported provider](https://docs.langchain.com/oss/javascript/integrations/chat). Default if you're unsure: **`anthropic:claude-sonnet-5`**.
+1. **Ask** which provider/model to use. Showcase that LangGraph works with any LangChain chat model. Suggested prompt:
 
-   Do not proceed until they answer or accept the default. Use their choice as `<MODEL>` below.
+   > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google-genai:gemini-2.5-flash-lite`. Default if you're unsure: **`anthropic:claude-sonnet-5`**.
 
-2. **Scaffold**
-   ```bash
-   mkdir langgraph-agent && cd langgraph-agent
-   npm init -y
-   npm install @langchain/langgraph @langchain/core langchain zod dotenv
-   ```
-   Install the matching provider package for `<MODEL>` (e.g. `@langchain/openai`, `@langchain/anthropic`, `@langchain/google-genai`).
-   Add `"type": "module"` to `package.json` if missing.
+   The docs often hardcode Anthropic — replace with `initChatModel("<MODEL>")` (or equivalent) using their choice. If using Claude Sonnet 5+, omit `temperature` / `top_p` / `top_k` (unsupported).
 
-3. **Write** `main.ts` — minimal ReAct graph with one stub tool. Use `initChatModel` from `langchain` with `<MODEL>`:
+2. Create a **new** directory (e.g. `langgraph-agent/`) and do all work there — do not pollute the open project.
 
-   ```typescript
-   import "dotenv/config";
-   import { initChatModel } from "langchain";
-   import { tool } from "@langchain/core/tools";
-   import { HumanMessage, SystemMessage, ToolMessage } from "@langchain/core/messages";
-   import { StateGraph, START, END, MessagesAnnotation } from "@langchain/langgraph";
-   import { z } from "zod";
+3. Only secret: the provider API key in `.env` (gitignored). No LangSmith / Tavily unless they ask. Prefer they edit `.env` themselves — don't paste keys into chat.
 
-   const model = await initChatModel("<MODEL>");
-   // If using Claude Sonnet 5+, omit temperature/top_p/top_k (unsupported).
-   // For older models you may pass { temperature: 0 }.
+4. Install packages from the quickstart plus the provider package for their model.
 
-   const getWeather = tool(
-     ({ city }) => `It's always sunny in ${city}!`,
-     {
-       name: "get_weather",
-       description: "Get weather for a given city",
-       schema: z.object({ city: z.string() }),
-     }
-   );
-
-   const toolsByName = { get_weather: getWeather };
-   const modelWithTools = model.bindTools([getWeather]);
-
-   async function llmCall(state: typeof MessagesAnnotation.State) {
-     const response = await modelWithTools.invoke([
-       new SystemMessage("You are a helpful assistant."),
-       ...state.messages,
-     ]);
-     return { messages: [response] };
-   }
-
-   async function toolNode(state: typeof MessagesAnnotation.State) {
-     const last = state.messages[state.messages.length - 1];
-     const results: ToolMessage[] = [];
-     for (const call of last.tool_calls ?? []) {
-       const observation = await toolsByName[call.name as keyof typeof toolsByName].invoke(
-         call.args
-       );
-       results.push(
-         new ToolMessage({ content: String(observation), tool_call_id: call.id! })
-       );
-     }
-     return { messages: results };
-   }
-
-   function shouldContinue(state: typeof MessagesAnnotation.State) {
-     const last = state.messages[state.messages.length - 1];
-     return last.tool_calls?.length ? "tool_node" : END;
-   }
-
-   const agent = new StateGraph(MessagesAnnotation)
-     .addNode("llm_call", llmCall)
-     .addNode("tool_node", toolNode)
-     .addEdge(START, "llm_call")
-     .addConditionalEdges("llm_call", shouldContinue, ["tool_node", END])
-     .addEdge("tool_node", "llm_call")
-     .compile();
-
-   const result = await agent.invoke({
-     messages: [new HumanMessage("What's the weather in San Francisco?")],
-   });
-   console.log(result.messages[result.messages.length - 1].content);
-   ```
-
-   If `MessagesAnnotation` / `initChatModel` imports differ in the installed version, follow the current JS LangGraph quickstart — keep the same graph shape.
-
-4. **Env**
-   - Create `.env` with a single empty placeholder for the key their provider needs.
-   - Ensure `.env` is in `.gitignore`.
-   - Ask them to fill it in, then wait.
-
-5. **Run** with `npx tsx main.ts` (install `tsx` if needed). Show the output. If it fails: missing provider package, blank key, or bad model id — fix and retry.
-
-6. **Done** — summarize files created. Suggest `langgraph-fundamentals`, `langgraph-persistence`, or `langgraph-human-in-the-loop` next. For a higher-level agent API, use LangChain `createAgent` instead.
+5. Run the example (e.g. “Add 3 and 4.”), show output, then stop. Point to `langgraph-fundamentals` for next steps. For a higher-level agent API, use LangChain `createAgent` instead.

--- a/config/skills/langgraph-typescript-quickstart/SKILL.md
+++ b/config/skills/langgraph-typescript-quickstart/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: langgraph-typescript-quickstart
+description: "Scaffold a minimal local LangGraph agent in TypeScript with StateGraph (tool-calling loop), one stub tool, and a provider API key. Use when the user wants to quickly build or try a LangGraph agent locally."
+---
+
+# LangGraph TypeScript quickstart
+
+Get a working local LangGraph agent with minimal setup. Inspired by the Graph API quickstart: https://docs.langchain.com/oss/javascript/langgraph/quickstart  
+(Uses a stub weather tool instead of the docs calculator so setup stays provider-key-only.)
+
+## Rules
+
+- Ask which **provider and model** to use (showcase model-agnosticism). Default to `anthropic:claude-sonnet-5` if they don't care.
+- Only secret: the provider API key. No Tavily, LangSmith, or other keys.
+- Create a **new** directory (e.g. `langgraph-agent/`) and do all work there. Do not add files to the user's currently open project.
+- Use a stub weather tool (no network). Prefer the user edits `.env` themselves — do not ask them to paste keys into chat.
+- Use the Graph API (`StateGraph`), not deprecated prebuilt ReAct helpers. Skip graph visualization.
+- Stop after a successful run. Briefly point to `langgraph-fundamentals` / docs for next steps.
+
+## Steps
+
+1. **Ask** for provider/model. Emphasize LangGraph works with any LangChain chat model — not locked to one vendor. Suggested prompt:
+
+   > Which model should this agent use? Pass a `provider:model` string — e.g. `openai:gpt-5.5`, `anthropic:claude-sonnet-5`, `google-genai:gemini-2.5-flash-lite`, or another [supported provider](https://docs.langchain.com/oss/javascript/integrations/chat). Default if you're unsure: **`anthropic:claude-sonnet-5`**.
+
+   Do not proceed until they answer or accept the default. Use their choice as `<MODEL>` below.
+
+2. **Scaffold**
+   ```bash
+   mkdir langgraph-agent && cd langgraph-agent
+   npm init -y
+   npm install @langchain/langgraph @langchain/core langchain zod dotenv
+   ```
+   Install the matching provider package for `<MODEL>` (e.g. `@langchain/openai`, `@langchain/anthropic`, `@langchain/google-genai`).
+   Add `"type": "module"` to `package.json` if missing.
+
+3. **Write** `main.ts` — minimal ReAct graph with one stub tool. Use `initChatModel` from `langchain` with `<MODEL>`:
+
+   ```typescript
+   import "dotenv/config";
+   import { initChatModel } from "langchain";
+   import { tool } from "@langchain/core/tools";
+   import { HumanMessage, SystemMessage, ToolMessage } from "@langchain/core/messages";
+   import { StateGraph, START, END, MessagesAnnotation } from "@langchain/langgraph";
+   import { z } from "zod";
+
+   const model = await initChatModel("<MODEL>");
+   // If using Claude Sonnet 5+, omit temperature/top_p/top_k (unsupported).
+   // For older models you may pass { temperature: 0 }.
+
+   const getWeather = tool(
+     ({ city }) => `It's always sunny in ${city}!`,
+     {
+       name: "get_weather",
+       description: "Get weather for a given city",
+       schema: z.object({ city: z.string() }),
+     }
+   );
+
+   const toolsByName = { get_weather: getWeather };
+   const modelWithTools = model.bindTools([getWeather]);
+
+   async function llmCall(state: typeof MessagesAnnotation.State) {
+     const response = await modelWithTools.invoke([
+       new SystemMessage("You are a helpful assistant."),
+       ...state.messages,
+     ]);
+     return { messages: [response] };
+   }
+
+   async function toolNode(state: typeof MessagesAnnotation.State) {
+     const last = state.messages[state.messages.length - 1];
+     const results: ToolMessage[] = [];
+     for (const call of last.tool_calls ?? []) {
+       const observation = await toolsByName[call.name as keyof typeof toolsByName].invoke(
+         call.args
+       );
+       results.push(
+         new ToolMessage({ content: String(observation), tool_call_id: call.id! })
+       );
+     }
+     return { messages: results };
+   }
+
+   function shouldContinue(state: typeof MessagesAnnotation.State) {
+     const last = state.messages[state.messages.length - 1];
+     return last.tool_calls?.length ? "tool_node" : END;
+   }
+
+   const agent = new StateGraph(MessagesAnnotation)
+     .addNode("llm_call", llmCall)
+     .addNode("tool_node", toolNode)
+     .addEdge(START, "llm_call")
+     .addConditionalEdges("llm_call", shouldContinue, ["tool_node", END])
+     .addEdge("tool_node", "llm_call")
+     .compile();
+
+   const result = await agent.invoke({
+     messages: [new HumanMessage("What's the weather in San Francisco?")],
+   });
+   console.log(result.messages[result.messages.length - 1].content);
+   ```
+
+   If `MessagesAnnotation` / `initChatModel` imports differ in the installed version, follow the current JS LangGraph quickstart — keep the same graph shape.
+
+4. **Env**
+   - Create `.env` with a single empty placeholder for the key their provider needs.
+   - Ensure `.env` is in `.gitignore`.
+   - Ask them to fill it in, then wait.
+
+5. **Run** with `npx tsx main.ts` (install `tsx` if needed). Show the output. If it fails: missing provider package, blank key, or bad model id — fix and retry.
+
+6. **Done** — summarize files created. Suggest `langgraph-fundamentals`, `langgraph-persistence`, or `langgraph-human-in-the-loop` next. For a higher-level agent API, use LangChain `createAgent` instead.


### PR DESCRIPTION
## Summary
- Adds six minimal local quickstart skills named `package-language-quickstart` (LangChain / LangGraph / Deep Agents × Python / TypeScript).
- Each skill asks for provider/model (defaults to `anthropic:claude-sonnet-5`) to showcase model-agnosticism, scaffolds a new directory, and requires only a provider API key.
- LangChain and LangGraph use a weather stub tool; Deep Agents use provider-native web search (Anthropic / OpenAI / Google) for a research-style demo without Tavily.
- Wires the new skills into `README.md`, `config/AGENTS.md`, and `ecosystem-primer`.

## Test plan
- [ ] Install one Python and one TypeScript quickstart skill and run through the flow with the Sonnet 5 default
- [ ] Confirm Deep Agents path uses provider web search and does not ask for `TAVILY_API_KEY`
- [ ] Confirm `.env` is gitignored and keys are not pasted into chat
- [ ] Spot-check skill discovery via `npx skills add langchain-ai/langchain-skills --skill langchain-python-quickstart`


Made with [Cursor](https://cursor.com)