### PR TITLE
Adding langsmith-eval-engineering skill to support LangSmith online eval creation

### DIFF
--- a/config/skills/langsmith-online-eval-engineering/SKILL.md
+++ b/config/skills/langsmith-online-eval-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: online-eval-engineering
-description: Iteratively inspect traces, interview the user, and create LangSmith online evaluators one at a time. Use for LLM-as-judge evaluators, code-based evaluators, automated trace scoring, or continuous quality monitoring.
+name: langsmith-online-eval-engineering
+description: Iteratively inspect traces, interview the user, and create LangSmith online evaluators one at a time. Use specifically for creating online evaluators for use within LangSmith -- use "eval-engineering" for Harbor-style online evaluations. 
 ---
 
 # Online Eval Engineering

--- a/config/skills/langsmith-online-eval-engineering/SKILL.md
+++ b/config/skills/langsmith-online-eval-engineering/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: online-eval-engineering
+description: Iteratively inspect traces, interview the user, and create LangSmith online evaluators one at a time. Use for LLM-as-judge evaluators, code-based evaluators, automated trace scoring, or continuous quality monitoring.
+---
+
+# Online Eval Engineering
+
+Build online evaluators iteratively:
+
+```text
+inspect traces and interview user -> propose directions -> user chooses
+-> build evaluator -> test, attach, verify -> review and repeat
+```
+
+Read [references/langsmith-api.md](references/langsmith-api.md) before creating or modifying evaluators.
+
+## 1. Inspect traces
+
+Ask the user for their LangSmith project name. Fetch recent root-level traces and print their structure. Read [references/trace-inspection.md](references/trace-inspection.md). Find:
+
+- run name and type;
+- available input and output field names;
+- the shape and content of the data (truncated samples);
+- which fields carry the data an evaluator would need.
+
+Summarize the trace structure in the conversation:
+
+```text
+Project: name
+Run type: chain | llm | tool | ...
+Input fields: field names and what they contain
+Output fields: field names and what they contain
+Sample: one representative input/output pair (truncated)
+```
+
+Keep the user involved: explain the trace structure and what it implies, then ask only for information the traces cannot establish. For example: "What does this application do?", "What quality concern matters most?", or "What failure should never happen?"
+
+Ask whether the user wants a naming prefix for evaluators in this session (e.g., `myapp-`, `v2-`, `dogfood-`). If they provide one, apply it to all evaluator names, prompt hub handles, and run rule display names. If they decline, use plain descriptive names.
+
+Do not propose evaluators until the trace structure is understood and the user has described their concerns.
+
+## 2. Discuss and choose an eval direction
+
+Read [references/evaluator-design.md](references/evaluator-design.md). Propose two or three evaluation criteria grounded in the trace data. Apply the naming prefix from step 1 if the user provided one. For each, give:
+
+```text
+Name: descriptive evaluator name (with prefix if set)
+Type: LLM-as-judge or code
+Measures: what quality dimension this evaluates
+Scoring: bool, float (0-1), or int; what pass/fail means
+Fields needed: which trace fields are used and how
+Rationale: why this type and approach
+```
+
+Example:
+
+```text
+Name: response-relevance
+Type: LLM-as-judge
+Measures: whether the response addresses the user's question
+Scoring: bool; True = relevant, False = off-topic or non-responsive
+Fields needed: input (user question), output (assistant response)
+Rationale: relevance is semantic and requires reading comprehension; not decidable by code
+```
+
+Recommend one and ask the user which to build. Do not implement until the user chooses.
+
+## 3. Build one evaluator
+
+Read [references/langsmith-api.md](references/langsmith-api.md). Build the selected evaluator. Show the full configuration to the user and get approval before executing any API calls.
+
+**LLM-as-judge path.** Define a `ResponseSchema` with `reasoning` first, then the score field. Write prompt messages with a clear rubric that assesses the result, not whether it matches a reference answer. Set `variable_mapping` using field names discovered in step 1. Present the schema, prompt, variable mapping, and evaluator name for approval. On approval, push the prompt and create the evaluator. Report the evaluator ID.
+
+**Code evaluator path.** Write a `perform_eval(run, example=None)` function. It must be self-contained (only builtins and standard library), access `run` as a dict (`run.get("outputs")`), and return `{"key": ..., "score": ..., "comment": ...}`. Present the function code and evaluator name for approval. On approval, create the evaluator. Report the evaluator ID.
+
+## 4. Test, attach, and verify
+
+Before attaching, ask the user what sampling rate they want (1.0 = every trace, 0.5 = half, 0.1 = 10%, or custom). Do not default silently. If the user is unsure, recommend 1.0 for initial testing.
+
+Ask the user whether they want to test the evaluator against a few existing traces before attaching. Run rules only fire on new traces, so historical testing is the only way to verify before new traffic arrives.
+
+For code evaluators, execute `perform_eval` directly against fetched root-level traces, passing a dict with `inputs`, `outputs`, and `attachments` keys. This catches runtime errors (wrong field names, dict-vs-object access, missing data) before production. For LLM evaluators, verify the configuration: confirm `variable_mapping` keys match prompt placeholders, confirm mapped trace fields exist, and check that the mapped data is meaningful.
+
+If testing reveals errors, fix and recreate before attaching. If the user declines testing, proceed to attach.
+
+Create a run rule to connect the evaluator to the tracing project. Apply the user's naming prefix to the `display_name`. Confirm the evaluator appears in the evaluator list with the correct project attachment. Inspect:
+
+- evaluator attachment and run rule status;
+- recent trace feedback and scores (from historical testing or new traces);
+- whether scores match expectations for the traces inspected;
+- edge case handling (empty output, errored runs, unexpected structure).
+
+Fix and reattach when the evaluator crashes, scores incorrectly, or fails on edge cases. Before approval, confirm the evaluator scored the intended quality dimension, not an infrastructure or data-shape failure.
+
+## 5. Review with the user
+
+Explain the evaluator name and ID, quality dimension and scoring approach, trace fields used, sampling rate, and any limitation. Ask the user to approve, revise, drop, or choose the next direction. If continuing, reuse the trace findings, then propose a distinct quality dimension.
+
+## Invariants
+
+- One quality dimension per evaluator.
+- No guessing field names; always inspect traces before implementing.
+- Show configuration and get user approval before making API calls.
+- Code evaluators must be self-contained: only builtins and standard library.
+- Code evaluators receive `run` as a plain dict; use `run.get("inputs")` and `run.get("outputs")`, not attribute access. The `example` parameter must default to `None`.
+- Treat API failures, auth errors, and run rule failures as infrastructure errors, not evaluator bugs.

--- a/config/skills/langsmith-online-eval-engineering/references/evaluator-design.md
+++ b/config/skills/langsmith-online-eval-engineering/references/evaluator-design.md
@@ -1,0 +1,127 @@
+# Evaluator Design
+
+Best practices for designing LangSmith online evaluators. One quality dimension per evaluator.
+
+## LLM-as-judge vs code: decision framework
+
+| Factor | LLM-as-judge | Code evaluator |
+|---|---|---|
+| **Use when** | Success is subjective or semantic | Success is objective or deterministic |
+| **Examples** | Relevance, helpfulness, safety, tone, factual grounding | Output exists, format validation, length thresholds, JSON structure, keyword presence |
+| **Speed** | Slower (LLM inference per trace) | Fast (direct execution) |
+| **Cost** | LLM token cost per evaluation | No additional cost |
+| **Determinism** | Non-deterministic; may vary across runs | Fully deterministic |
+
+**Rules of thumb:**
+- If you can write a Python expression that decides pass/fail, use code.
+- If a human would need to read and reason about the output, use an LLM judge.
+- When in doubt, start with an LLM judge -- you can always replace it with code later if the criterion turns out to be fully decidable.
+
+## LLM-as-judge best practices
+
+### Reasoning-first schema
+
+Always put a `reasoning` field before the score field in the Pydantic schema. This forces the LLM to explain before committing to a score, improving accuracy.
+
+```python
+class ResponseSchema(BaseModel):
+    reasoning: str = Field(
+        description="Step-by-step reasoning for the evaluation."
+    )
+    score: bool = Field(
+        description="Whether the response meets the criterion."
+    )
+```
+
+### Grounded rubrics
+
+Write the system prompt as a clear rubric. The evaluator should assess the result, not whether it matches a reference answer or preferred process.
+
+Good: "Does the response answer the user's question using information from the provided context?"
+
+Bad: "Does the response match the expected answer?" (there is no expected answer in online evaluation)
+
+### One quality per evaluator
+
+Each evaluator should measure exactly one quality dimension. Combining multiple criteria (e.g., relevance AND tone AND safety) in a single evaluator makes scores uninterpretable and harder to debug.
+
+Create separate evaluators for separate concerns:
+- `relevance-evaluator` -- Does the response address the question?
+- `safety-evaluator` -- Is the response free of harmful content?
+- `tone-evaluator` -- Is the tone appropriate for the context?
+
+### Variable mapping
+
+Map only the trace fields the prompt actually uses. Passing unused fields adds noise. See [trace-inspection.md](trace-inspection.md) for how to discover available fields.
+
+### Scoring types
+
+- **Boolean** (`bool`): pass/fail -- simplest, use when the criterion is binary.
+- **Numeric** (`float`, 0--1): granular scoring -- use when partial credit matters.
+- **Categorical** (`str`): labels -- use when the result is a category, not a scale.
+
+Use the simplest type that captures the distinction you need. Boolean is usually sufficient for online evaluation.
+
+## Code evaluator best practices
+
+### Access `run` as a dict
+
+`run` is a plain dict at runtime, not an object. Use `run.get("inputs")` and `run.get("outputs")` -- never `run.inputs` or `run.outputs`.
+
+`run.get("outputs")` can be `None` if the run errored. Always check:
+
+```python
+def perform_eval(run, example=None):
+    outputs = run.get("outputs")
+    if outputs is None:
+        return {"key": "my_check", "score": 0, "comment": "No output"}
+    # ... evaluate ...
+```
+
+### Self-contained
+
+Code evaluators cannot import external packages. All logic must be in the `perform_eval` function body using only Python builtins and the standard library. No `import numpy`, no `import requests`, no `import langchain`.
+
+### Descriptive keys
+
+The `"key"` in the return dict appears as the score name in the LangSmith UI. Use descriptive, lowercase, underscore-separated names:
+- `"has_output"` -- not `"check1"`
+- `"response_length"` -- not `"len"`
+- `"contains_greeting"` -- not `"g"`
+
+### Return types
+
+```python
+# Boolean (pass/fail)
+return {"key": "has_output", "score": True, "comment": "Output exists"}
+
+# Numeric (0-1 scale)
+return {"key": "response_length", "score": 0.75, "comment": "375 of 500 char target"}
+
+# Integer
+return {"key": "word_count", "score": 42, "comment": "42 words in response"}
+```
+
+## Anti-patterns
+
+| Anti-pattern | Problem | Fix |
+|---|---|---|
+| Guessing field names | Evaluator silently gets empty data | Inspect traces first |
+| Using `run.inputs` (attribute access) | `AttributeError` -- `run` is a dict | Use `run.get("inputs")` |
+| `def perform_eval(run, example)` without default | `TypeError` -- runtime passes one arg | Use `example=None` |
+| Multiple criteria in one evaluator | Ambiguous scores | One quality per evaluator |
+| Scoring against a reference answer | No reference exists in online eval | Score against a rubric |
+| External imports in code evaluator | Runtime error | Use only builtins/stdlib |
+| Ignoring `None` outputs | Crash on errored runs | Check `run.get("outputs") is None` |
+| Generic score names (`"score"`, `"result"`) | Indistinguishable in UI | Use descriptive keys |
+| Reasoning after score | LLM rationalizes instead of reasons | Put `reasoning` field first |
+
+## Mental verification checklist
+
+Before deploying an evaluator, mentally verify it against three cases:
+
+1. **Good trace**: A run where the agent performed well. Does the evaluator give a passing score?
+2. **Bad trace**: A run with a clear failure in the quality dimension. Does the evaluator give a failing score?
+3. **Edge case**: A run with missing output, empty input, or unusual structure. Does the evaluator handle it without crashing?
+
+If any case produces an unexpected result, revise the evaluator before deploying.

--- a/config/skills/langsmith-online-eval-engineering/references/langsmith-api.md
+++ b/config/skills/langsmith-online-eval-engineering/references/langsmith-api.md
@@ -1,0 +1,281 @@
+# LangSmith Online Evaluator API Reference
+
+Working code patterns for creating and managing LangSmith online evaluators. All snippets are derived from the [online-evals](https://github.com/langchain-ai/langchain-skills) reference scripts and tested against `langsmith >= 0.9.8`.
+
+## Setup
+
+```python
+from langsmith import Client
+
+client = Client()  # uses LANGSMITH_API_KEY from environment
+```
+
+Required environment variables:
+
+```
+LANGSMITH_API_KEY=lsv2_pt_...
+LANGSMITH_ENDPOINT=https://api.smith.langchain.com   # optional, this is the default
+```
+
+## Inspect traces
+
+Trace inspection uses synchronous SDK methods. Use this to discover field names before building an evaluator.
+
+```python
+import json
+from langsmith import Client
+
+client = Client()
+runs = list(client.list_runs(project_name="my-project", limit=5))
+
+for i, run in enumerate(runs):
+    print(f"--- Run {i + 1} (id: {run.id}) ---")
+    print(f"Name: {run.name}")
+    print(f"Run type: {run.run_type}")
+    print(f"Input keys: {list(run.inputs.keys()) if run.inputs else 'None'}")
+    print(f"Inputs: {json.dumps(run.inputs, indent=2, default=str)[:2000]}")
+    print(f"Output keys: {list(run.outputs.keys()) if run.outputs else 'None'}")
+    print(f"Outputs: {json.dumps(run.outputs, indent=2, default=str)[:2000]}")
+```
+
+Each run exposes: `.id`, `.name`, `.run_type`, `.inputs` (dict), `.outputs` (dict).
+
+## Create an LLM-as-judge evaluator
+
+LLM evaluators use a structured prompt pushed to the LangSmith Prompt Hub. All evaluator operations are async.
+
+### 1. Define the response schema
+
+```python
+from pydantic import BaseModel, Field
+
+class ResponseSchema(BaseModel):
+    reasoning: str = Field(
+        description="Step-by-step reasoning for the evaluation."
+    )
+    score: bool = Field(
+        description="Whether the response meets the criterion."
+    )
+```
+
+Put `reasoning` first so the LLM explains before scoring.
+
+### 2. Build and push the prompt
+
+```python
+from langchain_core.prompts.structured import StructuredPrompt
+
+PROMPT_MESSAGES = [
+    ("system", "Evaluate the following response against the criterion: ..."),
+    (
+        "human",
+        "User question: {input}\n\nAssistant response: {output}",
+    ),
+]
+
+prompt = StructuredPrompt.from_messages_and_schema(
+    PROMPT_MESSAGES,
+    schema=ResponseSchema.model_json_schema(),
+)
+
+url = client.push_prompt("my-evaluator", object=prompt)
+```
+
+### 3. Create the evaluator
+
+```python
+import asyncio
+
+async def create_llm_evaluator():
+    created = await client.evaluators.create(
+        name="my-evaluator",
+        type="llm",
+        llm_evaluator={
+            "prompt_repo_handle": "my-evaluator",
+            "commit_hash_or_tag": "latest",
+            "variable_mapping": {
+                "input": "input",
+                "output": "output",
+            },
+        },
+    )
+    return created.evaluator.id
+
+evaluator_id = asyncio.run(create_llm_evaluator())
+```
+
+### Variable mapping
+
+`variable_mapping` connects prompt template variables to top-level trace fields. The keys are template variable names (appearing as `{name}` in the prompt), and the values are trace field paths.
+
+Common mappings:
+
+| Template variable | Trace field | Notes |
+|---|---|---|
+| `input` | `input` | Top-level `run.inputs` |
+| `output` | `output` | Top-level `run.outputs` |
+
+Discover available fields using trace inspection above.
+
+## Create a code evaluator
+
+Code evaluators run a Python function directly against each trace. The function must be self-contained (no external imports).
+
+### Function signature
+
+```python
+def perform_eval(run, example=None):
+    """
+    Parameters:
+        run: dict with keys "inputs" (dict), "outputs" (dict), "attachments"
+        example: None for online evaluators (only set for dataset evals)
+
+    Returns:
+        dict with keys:
+            "key": str       -- evaluator identifier
+            "score": value   -- bool, int, or float
+            "comment": str   -- optional explanation
+    """
+```
+
+> **Important:** Two runtime constraints to be aware of:
+> 1. `example` must default to `None`. The online evaluator runtime calls `perform_eval(run)` with a single argument -- `example` is only passed for dataset evaluators.
+> 2. `run` is a plain **dict**, not an object. Use `run.get("inputs")` and `run.get("outputs")` -- not `run.inputs` or `run.outputs`. Attribute access will raise `AttributeError`.
+
+### Example: check whether output exists
+
+```python
+import textwrap
+
+EVALUATOR_CODE = textwrap.dedent("""\
+    def perform_eval(run, example=None):
+        \"\"\"Check whether the run produced any output.\"\"\"
+        outputs = run.get("outputs")
+        has_output = (
+            outputs is not None
+            and len(outputs) > 0
+        )
+        return {
+            "key": "has_output",
+            "score": bool(has_output),
+            "comment": "Run produced output" if has_output else "Run had no output",
+        }
+""")
+```
+
+### Create the evaluator
+
+```python
+async def create_code_evaluator():
+    created = await client.evaluators.create(
+        name="has-output",
+        type="code",
+        code_evaluator={
+            "code": EVALUATOR_CODE,
+            "language": "python",
+        },
+    )
+    return created.evaluator.id
+
+evaluator_id = asyncio.run(create_code_evaluator())
+```
+
+## Attach evaluator to a project (run rules)
+
+Run rules connect evaluators to tracing projects. The SDK does not have a dedicated run-rules wrapper, so use `httpx` against the REST API.
+
+```python
+import os
+import httpx
+from langsmith import Client
+
+client = Client()
+api_key = os.environ["LANGSMITH_API_KEY"]
+endpoint = os.environ.get("LANGSMITH_ENDPOINT", "https://api.smith.langchain.com")
+
+# Look up project ID
+project = client.read_project(project_name="my-project")
+
+# Create run rule
+resp = httpx.post(
+    f"{endpoint}/api/v1/runs/rules",
+    headers={"x-api-key": api_key},
+    json={
+        "display_name": f"eval-{project.name}",
+        "session_id": str(project.id),
+        "sampling_rate": 1.0,        # 1.0 = every trace, 0.1 = 10%
+        "evaluator_id": EVALUATOR_ID,
+        "is_enabled": True,
+    },
+    timeout=30,
+)
+resp.raise_for_status()
+
+rule = resp.json()
+print(f"Run rule created -> {rule['id']}")
+```
+
+### Payload reference
+
+| Field | Type | Description |
+|---|---|---|
+| `display_name` | str | Human-readable label in UI |
+| `session_id` | str (UUID) | Project ID (from `client.read_project`) |
+| `sampling_rate` | float | 0.0--1.0; fraction of traces to evaluate |
+| `evaluator_id` | str (UUID) | Evaluator ID from creation step |
+| `is_enabled` | bool | Whether the rule is active |
+
+## List, update, and delete evaluators
+
+### List all evaluators
+
+```python
+async def list_evaluators():
+    result = await client.evaluators.list()
+    for ev in result.evaluators:
+        projects = ""
+        if ev.run_rules:
+            projects = ", ".join(
+                r.session_name or str(r.session_id)
+                for r in ev.run_rules
+                if r.session_id
+            )
+        print(f"{ev.name:<30} {str(ev.id):<38} {ev.type:<6} {projects}")
+
+asyncio.run(list_evaluators())
+```
+
+> **Note:** The paginated result object uses `.evaluators` to access the list of evaluator objects. Some older examples may use `.data` -- this attribute was renamed in recent SDK versions.
+
+### Update an evaluator
+
+```python
+async def update_evaluator():
+    updated = await client.evaluators.update(
+        evaluator_id=EVALUATOR_ID,
+        name="renamed-evaluator",
+    )
+    print("Updated ->", updated.evaluator.id)
+
+asyncio.run(update_evaluator())
+```
+
+### Delete an evaluator
+
+```python
+async def delete_evaluator():
+    await client.evaluators.delete(
+        evaluator_id=EVALUATOR_ID,
+        delete_run_rules=True,  # also removes attached run rules
+    )
+    print("Deleted ->", EVALUATOR_ID)
+
+asyncio.run(delete_evaluator())
+```
+
+## Async patterns
+
+- **Evaluator operations** (`create`, `list`, `update`, `delete`) are async -- use `asyncio.run()` or `await` in an async context.
+- **Trace inspection** (`client.list_runs`) and **project lookup** (`client.read_project`) are synchronous.
+- **Run rules** use `httpx` (synchronous POST).
+- `client.push_prompt` is synchronous.

--- a/config/skills/langsmith-online-eval-engineering/references/trace-inspection.md
+++ b/config/skills/langsmith-online-eval-engineering/references/trace-inspection.md
@@ -1,0 +1,122 @@
+# Trace Inspection
+
+How to discover trace field names for use in evaluator `variable_mapping` (LLM evaluators) and `run.inputs`/`run.outputs` (code evaluators).
+
+Always inspect traces before building an evaluator. Never guess field names.
+
+## Procedure
+
+1. Ask the user for their LangSmith project name.
+2. Fetch 3--5 recent traces:
+
+```python
+from langsmith import Client
+
+client = Client()
+runs = list(client.list_runs(project_name="<project>", limit=5))
+```
+
+3. For each run, print:
+   - `run.name` -- the run name (often the chain or agent class)
+   - `run.run_type` -- `chain`, `llm`, `tool`, `retriever`, etc.
+   - `list(run.inputs.keys())` -- available input field names
+   - `list(run.outputs.keys())` -- available output field names
+   - Truncated samples of `run.inputs` and `run.outputs` (cap at ~2000 chars)
+
+4. Identify which fields carry the data the evaluator needs.
+
+## Common field name patterns
+
+### Chatbot / conversational agent
+
+```
+inputs:  {"input": "user message"}      or  {"messages": [...]}
+outputs: {"output": "assistant reply"}  or  {"messages": [...]}
+```
+
+Typical `variable_mapping`: `{"input": "input", "output": "output"}`
+
+### RAG / retrieval chain
+
+```
+inputs:  {"input": "user question", "chat_history": [...]}
+outputs: {"output": "answer", "context": [...]}
+```
+
+Context may appear as `"context"`, `"documents"`, or `"source_documents"`. Check the actual keys.
+
+### Tool-calling agent
+
+```
+inputs:  {"input": "user request"}
+outputs: {"output": "final answer"}
+```
+
+Tool calls appear in child runs, not in the top-level run's inputs/outputs. The top-level run still has `input` and `output` for the user-facing request and response.
+
+### Custom chains
+
+Field names depend on the chain's implementation. There is no universal schema -- this is why inspection is required.
+
+## Mapping fields to evaluators
+
+### LLM evaluators: `variable_mapping`
+
+`variable_mapping` connects prompt template variables to top-level trace fields. Only top-level fields are supported.
+
+```python
+# If the prompt template uses {question} and {answer}:
+VARIABLE_MAPPING = {
+    "question": "input",    # template var -> trace field
+    "answer": "output",
+}
+```
+
+The template variables must match `{placeholders}` in the prompt messages. The trace field values must match keys in `run.inputs` or `run.outputs`.
+
+### Code evaluators: `run["inputs"]` and `run["outputs"]`
+
+Code evaluators access trace data through the `run` dict:
+
+```python
+def perform_eval(run, example=None):
+    inputs = run.get("inputs") or {}
+    outputs = run.get("outputs") or {}
+    user_input = inputs.get("input", "")
+    agent_output = outputs.get("output", "")
+    # ... evaluate ...
+```
+
+`run` is a plain dict at runtime -- use `run.get("inputs")`, not `run.inputs`. Always use `.get()` with defaults and guard against `None` outputs.
+
+## Handling variations
+
+### Nested structures
+
+Some traces nest data inside wrapper keys:
+
+```
+inputs: {"input": {"question": "...", "context": "..."}}
+```
+
+For LLM evaluators, `variable_mapping` maps to top-level keys only. If data is nested, either:
+- Map to the top-level key and handle the nested structure in the prompt
+- Use a code evaluator instead, which can traverse nested dicts
+
+### Inconsistent schemas
+
+Different runs in the same project may have different field names if multiple chain types feed into one project. Inspect several traces to identify the common pattern. If schemas vary, a code evaluator with defensive `.get()` calls is more robust than an LLM evaluator with fixed `variable_mapping`.
+
+### Missing outputs
+
+Runs that errored may have `run["outputs"]` set to `None`. Code evaluators must handle this:
+
+```python
+def perform_eval(run, example=None):
+    outputs = run.get("outputs")
+    if outputs is None:
+        return {"key": "my_check", "score": 0, "comment": "No output (run may have errored)"}
+    # ... normal evaluation ...
+```
+
+LLM evaluators will receive an empty string for mapped fields when the trace field is missing.


### PR DESCRIPTION
Current documentation for online eval generation through the SDK is limited and poorly constructed, leading to high error rates, faulty eval creation, and orphaned prompts/evals. This Skill presents proper documentation/code examples and API documentation to mitigate common errors and challenges when creating, scoping, and attaching online evaluators to LangSmith tracing projects.

Extended @vtrivedy 's work and used the basis of the introspection/eval generation approach, but with LangSmith online evals as an output, rather than a Harbor task. Does not currently cover offline evals, as those are more well-defined and documented within existing documentation. 

Further work to be done:
- Update once SDK support to abstract away a prompt object as an intermediary step becomes available
- Update to reflect additional SDK evaluator parameters (sampling rate, model selection) as they become available
- Adapt to Messages/Trajectory endpoints when they become available
- Improve the introspection and task decomposition process 