### PR TITLE
Guidance on organizing environments & tasks

### DIFF
--- a/config/skills/eval-engineering/SKILL.md
+++ b/config/skills/eval-engineering/SKILL.md
@@ -9,7 +9,7 @@ Create one Harbor task at a time, run it, inspect the result, and repeat with th
 
 ```text
 map harness + environment -> propose directions -> user chooses
--> propose task boundary -> user approves -> build + run + audit -> repeat
+-> draft specs -> user approves -> build + run + audit -> repeat
 ```
 
 Use the latest Harbor release. Put task source under `evals/`.
@@ -65,19 +65,26 @@ Needs: known account records behind the existing read-only lookup
 
 Recommend one and explain why. The user chooses before implementation.
 
-## 3. Propose one task boundary
+## 3. Draft and approve the specs
 
-Read the Harness, task, Environment, and verifier references. Then give the user one proposal under 150 words:
+Read the Harness, task, Environment, and Verifier references. After the user chooses a direction, write:
 
 ```text
-Task: request and capability
-Harness: active repository entrypoint or a reconstruction, with lost behavior named
-Environment: live, frozen, or simulated dependencies/data; effects and credentials
-Verifier: independent evidence and pass condition
-Recommendation: preferred setup and why
+evals/specs/<task-id>/
+├── harness.md
+├── environment.md
+└── task.md
 ```
 
-For each dependency, recommend live, frozen, or simulated use. Read-only, low-cost services backed by hard-to-reproduce data are strong live candidates. Stable copied data is a strong frozen candidate. Writes, unstable services, and resettable state are strong simulation candidates. State required credentials for live use. The user approves or revises this boundary.
+These are control-plane review files. Never copy or mount them into the Harness workspace or task image. `task.md` is the review spec; Harbor's `instruction.md` is the Harness-visible request created from the approved spec.
+
+- `harness.md`: entrypoint, preserved behavior, adapter, sessions, credentials, recorded evidence, and reconstruction differences.
+- `environment.md`: live/frozen/simulated dependencies, backend contracts, generated or copied data, schemas and relationships, storage, effects, reset, and fidelity limits.
+- `task.md`: capability, request, initial conditions, pass condition, Verifier evidence, and accepted alternatives.
+
+For each dependency, recommend live, frozen, or simulated use. Read-only, low-cost services backed by hard-to-reproduce data are strong live candidates. Stable copied data is a strong frozen candidate. Writes, unstable services, and resettable state are strong simulation candidates. State required credential names for live use.
+
+Print the full contents of all three specs in the terminal, keeping them concise. Show their paths and your recommendation, then ask the user to approve or revise them. Mark each spec approved only after explicit user approval. Do not build the Harbor task until all three are approved. If implementation changes an approved boundary, update the affected spec, show the change, and obtain approval again.
 
 For multiple user turns, prefer fixed follow-ups when they do not depend on Harness responses. Use an LLM user only when replies must react, correct, reject, or stop; read the multi-turn reference and include simulator credentials in the proposal.
 

--- a/config/skills/eval-engineering/references/environment-building.md
+++ b/config/skills/eval-engineering/references/environment-building.md
@@ -22,6 +22,35 @@ It does not own the Harness's prompts, loop, model decisions, repository-defined
 
 Tell the user what is live, frozen, or synthetic; what credentials live access needs; and what effects are possible. Record a source revision, timestamp, or hash for copied data. Mark constructed records as synthetic.
 
+## Write `environment.md`
+
+Before implementation, write `evals/specs/<task-id>/environment.md`:
+
+```text
+Status: draft | approved
+Dependencies: name, live/frozen/simulated mode, implementation, credentials, effects
+Backend contracts: exercised operations, schemas, rules, failures, and permissions
+Data: each dataset's purpose, source or generation rule, structure, relationships,
+      representative records, storage backend, and reset
+Isolation: filesystem, network, identity, clock, and per-trial state
+Fidelity limits: behavior intentionally not reproduced
+```
+
+Make generated data concrete enough to review before it exists. Example:
+
+```text
+Dataset: accounts and tickets
+Purpose: require disambiguation between two same-name accounts
+Structure: accounts{id, name, plan, active}; tickets{id, account_id, status}
+Relationships: tickets.account_id -> accounts.id
+Records: two active Sam Lee accounts on different plans; one closed distractor
+Storage: seed.json materialized into SQLite tables `accounts` and `tickets`
+Generation: fixed synthetic records; neutral IDs and shuffled insertion order
+Reset: recreate the SQLite file from seed.json for every trial
+```
+
+Set `Status: approved` only after the user approves this file with `harness.md` and `task.md`.
+
 ## Define the backend contract
 
 Write the contract before choosing an implementation:

--- a/config/skills/eval-engineering/references/harness.md
+++ b/config/skills/eval-engineering/references/harness.md
@@ -11,6 +11,24 @@ It owns:
 
 The Environment owns what surrounds it: files, data, services behind tools, permissions, network, time, and mutable external state.
 
+## Write `harness.md`
+
+Before implementation, write `evals/specs/<task-id>/harness.md`:
+
+```text
+Status: draft | approved
+Entrypoint: exact callable or command
+Source: repository path and revision
+Preserved behavior: prompts, model loop, tools, hooks, memory, stopping
+Adapter: I/O translation and dependency binding, or none
+Session: single-turn or exact multi-turn persistence
+Credentials: environment-variable names only
+Recorded evidence: messages, model/tool calls, results, state, errors
+Reconstruction differences: none, or exact lost/changed behavior
+```
+
+Set `Status: approved` only after the user approves this file with `environment.md` and `task.md`.
+
 ## Choose what Harbor runs
 
 Prefer the active repository entrypoint. Use a reconstruction only when the entrypoint cannot run safely or reproducibly, and name what changes.

--- a/config/skills/eval-engineering/references/task-design.md
+++ b/config/skills/eval-engineering/references/task-design.md
@@ -2,6 +2,24 @@
 
 Design one request that makes the selected capability necessary.
 
+## Write `task.md`
+
+Before implementation, write `evals/specs/<task-id>/task.md`:
+
+```text
+Status: draft | approved
+Capability: behavior being measured
+Request: exact instruction later placed in Harbor's instruction.md
+Initial conditions: information, permissions, and state available
+Why this requires the capability: shortcut the task rules out
+Pass iff: independently observable successful outcome
+Verifier: LLM judge, deterministic check, or both
+Verifier evidence: exact sources, trajectory fields, or initial/final state
+Accepted alternatives: materially equivalent successful outcomes
+```
+
+`task.md` is a control-plane review spec, not Harness input. Set `Status: approved` only after the user approves it with `harness.md` and `environment.md`.
+
 ## The contract
 
 Define this before implementation:


### PR DESCRIPTION
## Summary

- add concise `harness.md`, `environment.md`, and `task.md` review specs
- require explicit user approval before building a Harbor task
- specify generated data schemas, relationships, storage, and reset behavior
- keep planning specs outside the Harness workspace and task image

## Testing

- `pnpm test` (172 tests)
- skill validation
- Python reference compilation
- `git diff --check`